### PR TITLE
Add Dockerfile.

### DIFF
--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -1,0 +1,11 @@
+FROM fabric8/java-jboss-openjdk8-jdk:1.2
+MAINTAINER Eiffel-Community
+USER root
+ARG EIFFEL_INTELLIGENCE_FRONTEND_VERSION
+RUN echo ${EIFFEL_INTELLIGENCE_FRONTEND_VERSION}
+ENV JAVA_APP_DIR=/deployments
+ENV JAVA_APP_JAR=eiffel-intelligence-frontend-${EIFFEL_INTELLIGENCE_FRONTEND_VERSION}.war
+EXPOSE 8090 8778 9779
+ADD https://jitpack.io/com/github/eiffel-community/eiffel-intelligence-frontend/${EIFFEL_INTELLIGENCE_FRONTEND_VERSION}/eiffel-intelligence-frontend-${EIFFEL_INTELLIGENCE_FRONTEND_VERSION}.war /deployments/eiffel-intelligence-frontend-${EIFFEL_INTELLIGENCE_FRONTEND_VERSION}.war
+
+

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -1,11 +1,11 @@
 FROM fabric8/java-jboss-openjdk8-jdk:1.2
 MAINTAINER Eiffel-Community
 USER root
-ARG EIFFEL_INTELLIGENCE_FRONTEND_VERSION
-RUN echo ${EIFFEL_INTELLIGENCE_FRONTEND_VERSION}
+ARG VERSION
+RUN echo ${VERSION}
 ENV JAVA_APP_DIR=/deployments
-ENV JAVA_APP_JAR=eiffel-intelligence-frontend-${EIFFEL_INTELLIGENCE_FRONTEND_VERSION}.war
+ENV JAVA_APP_JAR=eiffel-intelligence-frontend-${VERSION}.war
 EXPOSE 8090 8778 9779
-ADD https://jitpack.io/com/github/eiffel-community/eiffel-intelligence-frontend/${EIFFEL_INTELLIGENCE_FRONTEND_VERSION}/eiffel-intelligence-frontend-${EIFFEL_INTELLIGENCE_FRONTEND_VERSION}.war /deployments/eiffel-intelligence-frontend-${EIFFEL_INTELLIGENCE_FRONTEND_VERSION}.war
+ADD https://jitpack.io/com/github/eiffel-community/eiffel-intelligence-frontend/${VERSION}/eiffel-intelligence-frontend-${VERSION}.war /deployments/eiffel-intelligence-frontend-${VERSION}.war
 
 


### PR DESCRIPTION
Dockerfile for building Eiffel-Intelligence Frontend docker image.

Eiffel-Intelligence Frontend image is built with this command. Uses EI version from Jitpack:
`docker build -f src/main/docker/Dockerfile --build-arg VERSION=0.0.14 -t eiffelericsson/eiffel-intelligence-frontend:0.0.14 .`
or
`cd src/main/docker`
`docker build --build-arg VERSION=0.0.14 -t eiffelericsson/eiffel-intelligence-frontend:0.0.14 .`

Wiki page will be updated with this information when this has been merged.