### PR TITLE
Hide delete button

### DIFF
--- a/src/main/resources/templates/subscription.html
+++ b/src/main/resources/templates/subscription.html
@@ -163,8 +163,9 @@
                                                     placeholder="Value" class="form-control" type="text"></textarea>
                                             </td>
                                             <td valign="top" data-bind="visible: $root.formpostkeyvaluepairs">
-                                                <button data-bind="click: function(data, event) { $root.delete_NotificationMsgKeyValuePair(data, event, $index()); }, clickBubble: false"
-                                                    data-toggle="tooltip" title="Delete Key/Value Pair" class="btn btn-danger float-right">
+                                                <button data-bind="click: function(data, event) { $root.delete_NotificationMsgKeyValuePair(data, event, $index()); },
+                                                    clickBubble: false, style:{visibility:($root.subscription()[0].notificationMessageKeyValues().length > 1) ? 'visible' : 'hidden'}"
+                                                    data-toggle="tooltip" title="Delete Key/Value Pair" class="btn btn-danger float-right" style="visibility:hidden">
                                                     <i class="glyphicon glyphicon-trash"></i>Delete
                                                 </button>
                                             </td>


### PR DESCRIPTION
### Applicable Issues

Hide delete option from notification message when there is only one row

### Description of the Change
Modified delete button (for deletion of notification messages in subscription edit window). It is not visible anymore if there is only one notification message. Before it was only disabled and it confused users.

### Alternate Designs
I considered to create a JavaScript function for this but beacause we use Knockout framework, I decided to use it. In this way code is shorter and more readable.

### Benefits
More intuitive

### Possible Drawbacks
None

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Jakub Binieda, jakub.binieda@ericsson.com
