### PR TITLE
Fix configuration for maven-surefire-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -154,6 +154,7 @@
         <configuration>
           <forkCount>2C</forkCount>
           <reuseForks>false</reuseForks>
+          <useSystemClassLoader>false</useSystemClassLoader>
           <excludes>
             <exclude>${someModule.test.excludes}</exclude>
           </excludes>


### PR DESCRIPTION
### Applicable Issues
When trying to run any single functional test or all functional tests using maven goal this 
error was logged in the surefire-reports: "Error: Could not find or load main class org.apache.maven.surefire.booter.ForkedBooter"

Previously the configuration responsible for class loading "useSystemClassLoader" was default false but later versions changes to default true which causes this error. More info on class loading [maven-surefire-plugin docs](http://maven.apache.org/surefire/maven-surefire-plugin/examples/class-loading.html)

### Description of the Change
Setting configuration "useSystemClassLoader" to false enables running the functional tests as mvn goals. 

### Sign-off
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Emelie Pettersson emelie.pettersson@ericsson.com
