### PR TITLE
Fixed problem with removing specific rule from Test Rules

### DIFF
--- a/src/main/resources/static/js/testrules.js
+++ b/src/main/resources/static/js/testrules.js
@@ -157,7 +157,7 @@ jQuery(document).ready(
 
         // This function for adding rule
         self.addRule = function() {
-          self.rulesBindingList.push(ruleTemplate);
+          self.rulesBindingList.push(JSON.parse(JSON.stringify(ruleTemplate)));
         };
         // This function for adding rule
         self.addEvent = function() {


### PR DESCRIPTION
### Applicable Issues
After adding new rules, delete button does not remove the specific rule, only the last one.

### Description of the Change
The problem was with the creation of the new rule box. Add function used everytime the same variable that contained address, not value. Now it creates new instance every time, and removing one object from array does not affect other object.

### Alternate Designs
None

### Benefits
It is possible to remove specific rule.

### Possible Drawbacks
None

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Jakub Binieda, jakub.binieda@ericsson.com
