### PR TITLE
Fixed upload button for rules and events in IE and Edge

### DIFF
--- a/src/main/resources/static/js/testrules.js
+++ b/src/main/resources/static/js/testrules.js
@@ -262,15 +262,8 @@ jQuery(document).ready(
           validateRulesJsonAndCreateSubscriptions(file);
         }
 
-        // If MS Internet Explorer -> special handling for creating
-        // download
-        // file window.
-        if (window.navigator.msSaveOrOpenBlob) {
-          createUploadWindowMSExplorer();
-        } else {
-          // HTML5 Download File window handling
-          createRulesUploadWindow();
-        }
+        // HTML5 Download File window handling
+        createRulesUploadWindow();
       });
 
       //Upload list of events json data
@@ -294,14 +287,9 @@ jQuery(document).ready(
           validateEventsJsonAndCreateSubscriptions(file);
         }
 
-        // If MS Internet Explorer -> special handling for creating download
-        // file window.
-        if (window.navigator.msSaveOrOpenBlob) {
-          createUploadWindowMSExplorer();
-        } else {
-          // HTML5 Download File window handling
-          createUploadWindow();
-        }
+
+        // HTML5 Download File window handling
+        createUploadWindow();
       });
 
       // Download the modified rule


### PR DESCRIPTION
### Applicable Issues
The button to upload test rules and events are not working in MS Explorer and MS Edge. No popup window to select json file appears.

### Description of the Change
I removed special case from if statement that created a problem in newer versions of IE and Edge.

### Alternate Designs
None

### Benefits
Popup window appears now in IE and Edge.

### Possible Drawbacks
Older versions of IE maybe can  have a problem with that,

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Jakub Binieda, jakub.binieda@ericsson.com
