### PR TITLE
Hide remove button of default backend instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,15 @@ To get involved, please see [Code of Conduct](./CODE_OF_CONDUCT.md) and [contrib
 This repository forms part of the Eiffel Community. Eiffel is a protocol for technology agnostic machine-to-machine communication in continuous integration and delivery pipelines, aimed at securing scalability, flexibility and traceability. Eiffel is based on the concept of decentralized real time messaging, both to drive the continuous integration and delivery system and to document it.
 
 Visit [Eiffel Community](https://eiffel-community.github.io) to get started and get involved.
+
+# Documentation
+
+1. [**GUI Overview**](./wiki/GUI-Overview.md)
+1. [**Subscription Handling**](./wiki/Subscription-Handling.md)
+    -  [**Add Subscription**](./wiki/Add-Subscription.md)
+1. [**Test Rules**](./wiki/Test-Rules.md)
+    - [**Rule testing mechanism via "Test Rules" GUI interface**](./wiki/Test-Rules.md#Rule-testing-mechanism-via-Test-Rules-GUI-interface)
+    - [**Introduction**](./wiki/Test-Rules.md#Introduction)
+    - [**Aggregated object**](./wiki/Test-Rules.md#Aggregated-object)
+    - [**Rule set up**](./wiki/Test-Rules.md#Rule-set-up)
+    - [**The most common operation you would do**](./wiki/Test-Rules.md#The-most-common-operation-you-would-do)

--- a/pom.xml
+++ b/pom.xml
@@ -152,7 +152,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <version>2.20</version>
         <configuration>
-          <forkCount>2C</forkCount>
+          <forkCount>2.5C</forkCount>
           <reuseForks>false</reuseForks>
           <useSystemClassLoader>false</useSystemClassLoader>
           <excludes>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>com.github.ericsson</groupId>
   <artifactId>eiffel-intelligence-frontend</artifactId>
-  <version>0.0.16</version>
+  <version>0.0.17</version>
   <packaging>war</packaging>
   <parent>
     <groupId>org.springframework.boot</groupId>

--- a/src/functionaltest/java/com/ericsson/ei/frontend/TestSubscriptionHandling.java
+++ b/src/functionaltest/java/com/ericsson/ei/frontend/TestSubscriptionHandling.java
@@ -53,19 +53,17 @@ public class TestSubscriptionHandling extends SeleniumBaseClass {
         // present AND there exists "edit" and" delete buttons" for unauthorized
         // user "ABCD"
         String response = getJSONStringFromFile(SUBSCRIPTION_FOR_RELOAD_TEST_FILE_PATH);
-        String viewButtonXPath = "(//button[@id='view-Subscription1'])[2]";
-        String editButtonXPath = "(//button[@id='edit-Subscription1'])[2]";
-        String deleteButtonXPath = "(//button[@id='delete-Subscription1'])[2]";
-        String expandButtonXPath = "//tr[contains(.,'Subscription1')]/td[1]";
 
         subscriptionPage.clickReload(response);
 
-        assert (subscriptionPage.textExistsInTable("Subscription1"));
-        assert (subscriptionPage.textExistsInTable("Subscription2"));
-        assert (subscriptionPage.clickElementByXPath(expandButtonXPath));
-        assert (subscriptionPage.buttonExist(deleteButtonXPath));
-        assert (subscriptionPage.buttonExist(editButtonXPath));
-        assert (subscriptionPage.buttonExist(viewButtonXPath));
+        String expandButtonXPath = "//tr[contains(.,'Subscription1')]/td[1]";
+        String viewButtonXPath = "(//button[@id='view-Subscription1'])";
+        String editButtonXPath = "(//button[@id='edit-Subscription1'])";
+        String deleteButtonXPath = "(//button[@id='delete-Subscription1'])";
+        assert (subscriptionPage.clickExpandButtonByXPath(expandButtonXPath));
+        assert (subscriptionPage.buttonExistByXPath(deleteButtonXPath));
+        assert (subscriptionPage.buttonExistByXPath(editButtonXPath));
+        assert (subscriptionPage.buttonExistByXPath(viewButtonXPath));
 
         // Given LDAP is enabled, "Reload" subscriptions and then click
         // subscription page with LDAP enabled with unauthorized user names
@@ -76,10 +74,10 @@ public class TestSubscriptionHandling extends SeleniumBaseClass {
         subscriptionPage.clickReloadLDAP(responseSub, responseAuth);
         indexPageObject.clickSubscriptionPage();
 
-        assert (subscriptionPage.clickElementByXPath(expandButtonXPath));
-        assert (!subscriptionPage.buttonExist(deleteButtonXPath));
-        assert (!subscriptionPage.buttonExist(editButtonXPath));
-        assert (subscriptionPage.buttonExist(viewButtonXPath));
+        assert (subscriptionPage.clickExpandButtonByXPath(expandButtonXPath));
+        assert (!subscriptionPage.buttonExistByXPath(deleteButtonXPath));
+        assert (!subscriptionPage.buttonExistByXPath(editButtonXPath));
+        assert (subscriptionPage.buttonExistByXPath(viewButtonXPath));
 
         // Given LDAP is enabled, "Reload" subscriptions and then click
         // subscription page with LDAP enabled with both unauthorized and
@@ -95,25 +93,26 @@ public class TestSubscriptionHandling extends SeleniumBaseClass {
         indexPageObject.clickSubscriptionPage();
 
         assert (subscriptionPage.textExistsInTable("Subscription1"));
-        assert (subscriptionPage.clickElementByXPath(expandButtonXPath));
-        assert (subscriptionPage.buttonExist(deleteButtonXPath));
-        assert (subscriptionPage.buttonExist(editButtonXPath));
-        assert (subscriptionPage.buttonExist(viewButtonXPath));
+        assert (subscriptionPage.clickExpandButtonByXPath(expandButtonXPath));
+        assert (subscriptionPage.buttonExistByXPath(deleteButtonXPath));
+        assert (subscriptionPage.buttonExistByXPath(editButtonXPath));
+        assert (subscriptionPage.buttonExistByXPath(viewButtonXPath));
 
         // Now, path for "subscriptions2" with user name "DEF", so user "ABCD"
         // is unauthorized for this subscription
-        String viewButtonXPath2 = "(//button[@id='view-Subscription2'])[2]";
-        String editButtonXPath2 = "(//button[@id='edit-Subscription2'])[2]";
-        String deleteButtonXPath2 = "(//button[@id='delete-Subscription2'])[2]";
+        String viewButtonXPath2 = "(//button[@id='view-Subscription2'])";
+        String editButtonXPath2 = "(//button[@id='edit-Subscription2'])";
+        String deleteButtonXPath2 = "(//button[@id='delete-Subscription2'])";
         String expandButtonXPath2 = "//tr[contains(.,'Subscription2')]/td[1]";
 
-        assert (subscriptionPage.clickElementByXPath(expandButtonXPath2));
-        assert (subscriptionPage.buttonExist(viewButtonXPath2));
-        assert (!subscriptionPage.buttonExist(editButtonXPath2));
-        assert (!subscriptionPage.buttonExist(deleteButtonXPath2));
+        assert (subscriptionPage.clickExpandButtonByXPath(expandButtonXPath2));
+        assert (subscriptionPage.buttonExistByXPath(viewButtonXPath2));
+        subscriptionPage.clickViewButtonByXPath(viewButtonXPath2);
+        assert (!subscriptionPage.buttonExistByXPath(editButtonXPath2));
+        assert (!subscriptionPage.buttonExistByXPath(deleteButtonXPath2));
 
         // Test view button
-        subscriptionPage.clickElementByXPath(viewButtonXPath2);
+        subscriptionPage.clickViewButtonByXPath(viewButtonXPath2);
         assert (new WebDriverWait(driver, 10)
                 .until((webdriver) -> driver.getPageSource().contains("View Subscription")));
         subscriptionPage.clickFormCloseBtn();
@@ -163,29 +162,34 @@ public class TestSubscriptionHandling extends SeleniumBaseClass {
         // On subscription form, select the template as "Mail Trigger" and
         // verify
         String selectID = "selectTemplate";
+        String mailRadioID = "mailRadio";
+        String notificationMetaInputID = "notificationMeta";
         String tempMail = "Mail Trigger";
         subscriptionPage.selectDropdown(selectID, tempMail);
-        assert (new WebDriverWait(driver, 10)
-                .until((webdriver) -> (subscriptionPage.getValueFromSelect().equals("MAIL"))));
-        assert (new WebDriverWait(driver, 10)
-                .until((webdriver) -> (subscriptionPage.getValueFromElement().equals("mymail@company.com"))));
+        assert (subscriptionPage.isRadioCheckboxSelected(mailRadioID));
+        assertEquals ("mymail@company.com", subscriptionPage.getValueFromElement(notificationMetaInputID));
 
         // On subscription form, select the template as "REST POST (Raw
         // Body:JSON)" and verify
         String tempPost = "REST POST (Raw Body : JSON)";
+        String restPostRadio = "restPostRadio";
+        String keyValueRadio = "keyValueRadio";
+        String appJsonRadio = "appJsonRadio";
         subscriptionPage.selectDropdown(selectID, tempPost);
-        assert (new WebDriverWait(driver, 10)
-                .until((webdriver) -> (subscriptionPage.getValueFromSelect().equals("REST_POST"))));
-        assert (new WebDriverWait(driver, 10).until(
-                (webdriver) -> (subscriptionPage.getValueFromElement().equals("http://<MyHost:port>/api/doit"))));
+        assert (subscriptionPage.isRadioCheckboxSelected(restPostRadio));
+        assert (subscriptionPage.isRadioCheckboxSelected(appJsonRadio));
+        assert (!subscriptionPage.isRadioCheckboxSelected(keyValueRadio));
+        assertEquals ("http://<MyHost:port>/api/doit", subscriptionPage.getValueFromElement(notificationMetaInputID));
 
         // On subscription form, select the template as "Jenkins Pipeline
-        // Parameterized Job Trigger" and verify
+        // Parameterized Job Trigger" and verify RawBody unselected.
         String tempJenkins = "Jenkins Pipeline Parameterized Job Trigger";
         subscriptionPage.selectDropdown(selectID, tempJenkins);
-        assertEquals("REST_POST", subscriptionPage.getValueFromSelect());
+        assert (subscriptionPage.isRadioCheckboxSelected(restPostRadio));
+        assert (subscriptionPage.isRadioCheckboxSelected(keyValueRadio));
+        assert (!subscriptionPage.isRadioCheckboxSelected(appJsonRadio));
         assertEquals("http://<JenkinsHost:port>/job/<JobName>/job/<branch>/build",
-                subscriptionPage.getValueFromElement());
+                subscriptionPage.getValueFromElement(notificationMetaInputID));
 
         // Choose Authorization as "Basic_AUTH" ===> input User Name as "ABCD"
         // and Token as "EFGH" ===> click "Generate Key/Value Pair", verify the
@@ -196,13 +200,6 @@ public class TestSubscriptionHandling extends SeleniumBaseClass {
         String userNameID = "userNameInput";
         String password = "password";
         String passwordID = "passwordInput";
-        String subName = "Selenium_test_subscription";
-        String subNameID = "subscriptionNameInput";
-        String selectRepeatID = "selectRepeat";
-        String repeatValue = "true";
-        String conditionFieldID = "conditionID";
-        String requirementFieldID = "requirementID";
-
         subscriptionPage.selectDropdown(selectAuthID, authValue);
         subscriptionPage.addFieldValue(userNameID, userName);
         subscriptionPage.addFieldValue(passwordID, password);
@@ -210,29 +207,30 @@ public class TestSubscriptionHandling extends SeleniumBaseClass {
         assert (new WebDriverWait(driver, 10).until((webdriver) -> driver.getPageSource().contains("ABCD")));
         assert (new WebDriverWait(driver, 10).until((webdriver) -> driver.getPageSource().contains("password")));
 
-        // Test "Repeat" dropdown: Select repeat value as "true" and then verify the selected value
-        subscriptionPage.selectDropdown(selectRepeatID, repeatValue);
-        assert (new WebDriverWait(driver, 10)
-              .until((webdriver) -> (subscriptionPage.getValueFromSelectRepeat().equals(repeatValue))));
+        // Test "Repeat" checkbox: verify unchecked, then checked.
+        // NOTE: repeat checkbox is covered by a span, we click span
+        String checkboxRepeatID = "repeatCheckbox";
+        String spanId = "repeatCheckboxSpan";
+        assert (!subscriptionPage.isCheckboxSelected(checkboxRepeatID));
+        subscriptionPage.clickSpanAroundCheckbox(checkboxRepeatID, spanId);
+        assert (subscriptionPage.isCheckboxSelected(checkboxRepeatID));
 
         // Test "Add Condition" button: click add condition button and check that it adds an additional "condition" field
+        String conditionFieldID = "conditionID";
         subscriptionPage.clickAddConditionBtn();
         assertEquals(2, subscriptionPage.countElements(conditionFieldID));
 
         // Test "Add Requirement" button: click the button and assert that it adds an additional "requirement" field
+        String requirementFieldID = "requirementID";
         subscriptionPage.clickAddRequirementBtn();
         assertEquals(2, subscriptionPage.countElements(requirementFieldID));
-
-        // Test "Repeat" dropdown: Select repeat value as "true" and then verify
-        // the selected value
-        subscriptionPage.selectDropdown(selectRepeatID, repeatValue);
-        assert (new WebDriverWait(driver, 10)
-                .until((webdriver) -> (subscriptionPage.getValueFromSelectRepeat().equals(repeatValue))));
 
         // Test save subscription form: add subscription name
         // as "selenium_test_subscription" and then click "save" button
         // verification that subscription is added in the datatable (and is
         // displayed on the main page)
+        String subName = "Selenium_test_subscription";
+        String subNameID = "subscriptionNameInput";
         String responseSave = getJSONStringFromFile(SUBSCRIPTION_FOR_SAVE_TEST_FILE_PATH);
         subscriptionPage.addFieldValue(subNameID, subName);
         subscriptionPage.clickFormsSaveBtn(responseSave);

--- a/src/functionaltest/java/com/ericsson/ei/frontend/pageobjects/SubscriptionPage.java
+++ b/src/functionaltest/java/com/ericsson/ei/frontend/pageobjects/SubscriptionPage.java
@@ -101,25 +101,48 @@ public class SubscriptionPage extends PageBaseClass {
         dropdown.selectByVisibleText(value);
     }
 
-    public String getValueFromSelect() {
+    public boolean isRadioCheckboxSelected(String id) {
         new WebDriverWait(driver, TIMEOUT_TIMER)
-                .until(ExpectedConditions.elementToBeClickable(By.id("notificationType")));
-        WebElement selectNotificationType = driver.findElement(By.id("notificationType"));
-        Select dropdown = new Select(selectNotificationType);
-        return dropdown.getFirstSelectedOption().getText();
+                .until(ExpectedConditions.elementToBeClickable(By.id(id)));
+        WebElement checkbox = driver.findElement(By.id(id));
+        boolean radioBtnIsSelected = checkbox.isSelected();
+        return radioBtnIsSelected;
     }
-    
-    public String getValueFromSelectRepeat() {
+
+    public boolean isCheckboxSelected(String id) {
         new WebDriverWait(driver, TIMEOUT_TIMER)
-                .until(ExpectedConditions.elementToBeClickable(By.id("selectRepeat")));
-        WebElement selectNotificationType = driver.findElement(By.id("selectRepeat"));
+                .until(ExpectedConditions.presenceOfElementLocated(By.id(id)));
+        WebElement checkbox = driver.findElement(By.id(id));
+        boolean isSelected = checkbox.isSelected();
+        return isSelected;
+    }
+
+    public void clickSpanAroundCheckbox(String id, String spanId) {
+        new WebDriverWait(driver, TIMEOUT_TIMER)
+                .until(ExpectedConditions.presenceOfElementLocated(By.id(id)));
+        new WebDriverWait(driver, TIMEOUT_TIMER)
+                .until(ExpectedConditions.presenceOfElementLocated(By.id(spanId)));
+
+        WebElement checkbox = driver.findElement(By.id(id));
+        WebElement span = driver.findElement(By.id(spanId));
+
+        span.click();
+
+        new WebDriverWait(driver, TIMEOUT_TIMER)
+                .until(ExpectedConditions.elementSelectionStateToBe(checkbox, true));
+    }
+
+    public String getValueFromSelect(String id) {
+        new WebDriverWait(driver, TIMEOUT_TIMER)
+                .until(ExpectedConditions.elementToBeClickable(By.id(id)));
+        WebElement selectNotificationType = driver.findElement(By.id(id));
         Select dropdown = new Select(selectNotificationType);
         return dropdown.getFirstSelectedOption().getText();
     }
 
-    public String getValueFromElement() {
-        new WebDriverWait(driver, TIMEOUT_TIMER).until(ExpectedConditions.elementToBeClickable(By.id("metaData")));
-        WebElement metaTxt = driver.findElement(By.id("metaData"));
+    public String getValueFromElement(String id) {
+        new WebDriverWait(driver, TIMEOUT_TIMER).until(ExpectedConditions.elementToBeClickable(By.id(id)));
+        WebElement metaTxt = driver.findElement(By.id(id));
         return metaTxt.getAttribute("value");
     }
 
@@ -172,13 +195,13 @@ public class SubscriptionPage extends PageBaseClass {
         WebElement viewBtn = driver.findElement(By.className("close"));
         viewBtn.click();
     }
-    
+
     public void clickAddConditionBtn() {
         new WebDriverWait(driver, TIMEOUT_TIMER).until(ExpectedConditions.elementToBeClickable(By.id("addCondition")));
         WebElement viewBtn = driver.findElement(By.id("addCondition"));
         viewBtn.click();
     }
-    
+
     public void clickAddRequirementBtn(){
         new WebDriverWait(driver, TIMEOUT_TIMER).until(ExpectedConditions.elementToBeClickable(By.id("addRequirement")));
         WebElement viewBtn = driver.findElement(By.id("addRequirement"));
@@ -192,13 +215,32 @@ public class SubscriptionPage extends PageBaseClass {
         return subscriptionNameElement.getText();
     }
 
-    public boolean buttonExist(String loc) {
+    public boolean expandButtonExist(String XPath) {
         try {
-            new WebDriverWait(driver, TIMEOUT_TIMER).until(ExpectedConditions.elementToBeClickable(By.xpath(loc)));
+            new WebDriverWait(driver, TIMEOUT_TIMER).until(ExpectedConditions.elementToBeClickable(By.xpath(XPath)));
         } catch (Exception e) {
             return false;
         }
         return true;
+    }
+
+    public boolean buttonExistByXPath(String XPath) {
+        // The row indicates weather or not the del / view and edit buttons has moved down to
+        // next row.
+        String findInRow;
+        try {
+            findInRow = "[2]";
+            new WebDriverWait(driver, TIMEOUT_TIMER).until(ExpectedConditions.elementToBeClickable(By.xpath(XPath + findInRow)));
+            return true;
+        } catch (Exception e) {
+        }
+        try {
+            findInRow = "[1]";
+            new WebDriverWait(driver, TIMEOUT_TIMER).until(ExpectedConditions.elementToBeClickable(By.xpath(XPath + findInRow)));
+            return true;
+        } catch (Exception e) {
+        }
+        return false;
     }
 
     public void clickReloadLDAP(String response, String responseAuth) throws IOException {
@@ -222,17 +264,41 @@ public class SubscriptionPage extends PageBaseClass {
         return true;
     }
 
-    public boolean clickElementByXPath(String loc) {
+    public boolean clickExpandButtonByXPath(String loc) {
         try {
-            new WebDriverWait(driver, TIMEOUT_TIMER).until(ExpectedConditions.elementToBeClickable(By.xpath(loc)));
-            driver.findElement(By.xpath(loc)).click();
+            if (expandButtonExist(loc)) {
+                new WebDriverWait(driver, TIMEOUT_TIMER).until(ExpectedConditions.elementToBeClickable(By.xpath(loc)));
+                driver.findElement(By.xpath(loc)).click();
+            } else {
+                return true;
+            }
         } catch (Exception e) {
             return false;
         }
         return true;
     }
-    
+
     public int countElements(String id) {
-    	return driver.findElements(By.id(id)).size();   	
+    	return driver.findElements(By.id(id)).size();
     }
+
+    public void clickViewButtonByXPath(String XPath) {
+        // The row indicates weather or not the del / view and edit buttons has moved down to
+        // next row.
+        try {
+            String Xpath2 = XPath + "[2]";
+            new WebDriverWait(driver, TIMEOUT_TIMER).until(ExpectedConditions.elementToBeClickable(By.xpath(Xpath2)));
+            driver.findElement(By.xpath(Xpath2)).click();
+            return;
+        } catch (Exception e) {
+        }
+        try {
+            String Xpath1 = XPath + "[1]";
+            new WebDriverWait(driver, TIMEOUT_TIMER).until(ExpectedConditions.elementToBeClickable(By.xpath(Xpath1)));
+            driver.findElement(By.xpath(Xpath1)).click();
+            return;
+        } catch (Exception e) {
+        }
+    }
+
 }

--- a/src/main/java/com/ericsson/ei/frontend/utils/BackEndInfoirmationControllerUtils.java
+++ b/src/main/java/com/ericsson/ei/frontend/utils/BackEndInfoirmationControllerUtils.java
@@ -16,9 +16,7 @@
 */
 package com.ericsson.ei.frontend.utils;
 
-import java.io.IOException;
 import java.net.URI;
-import java.util.Iterator;
 import java.util.NoSuchElementException;
 import java.util.stream.Collectors;
 
@@ -84,7 +82,7 @@ public class BackEndInfoirmationControllerUtils {
      */
     public ResponseEntity<String> handleRequestToSwitchBackEnd(HttpServletRequest request) {
         try {
-            String selectedInstanceName = getSelectedInstanceName(request);
+            String selectedInstanceName = request.getReader().lines().collect(Collectors.joining(System.lineSeparator()));
             request.getSession().setAttribute("backEndInstanceName", selectedInstanceName);
 
             return new ResponseEntity<>(
@@ -169,34 +167,6 @@ public class BackEndInfoirmationControllerUtils {
         httpHeaders.setContentType(MediaType.APPLICATION_JSON);
         httpHeaders.setLocation(URI.create("/"));
         return httpHeaders;
-    }
-
-    private String getSelectedInstanceName(HttpServletRequest request) throws IOException {
-        String selectedInstanceName = null;
-        String inputPostDataAsString = request.getReader().lines().collect(Collectors.joining(System.lineSeparator()));
-        if (isJsonFormatted(inputPostDataAsString)) {
-            JsonArray listofInstances = new JsonParser().parse(inputPostDataAsString).getAsJsonArray();
-
-            for (JsonElement element : listofInstances) {
-                if (element.getAsJsonObject().get("active").getAsBoolean() == true) {
-                    selectedInstanceName = element.getAsJsonObject().get("name").getAsString();
-                    break;
-                }
-            }
-        } else {
-            selectedInstanceName = inputPostDataAsString;
-        }
-
-        return selectedInstanceName;
-    }
-
-    private boolean isJsonFormatted(String listOfInstances) {
-        try {
-            new JsonParser().parse(listOfInstances).getAsJsonArray();
-            return true;
-        } catch (Exception e) {
-            return false;
-        }
     }
 
     private JsonArray setActiveInstance(JsonArray allAvailableInstances, String activeInstance) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -22,7 +22,7 @@ ei.backendServerHost=localhost
 ei.backendServerPort=8090
 ei.backendContextPath=
 ei.useSecureHttpBackend=false
-ei.backendInstancesPath=
+ei.backendInstancesFilePath=
 
 ###### EI Documentation Link Url ##########
 ei.eiffelDocumentationUrls={ "EI Frontend GitHub": "https://github.com/eiffel-community/eiffel-intelligence-frontend",\

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -28,7 +28,7 @@ ei.backendInstancesFilePath=
 ei.eiffelDocumentationUrls={ "EI Frontend GitHub": "https://github.com/eiffel-community/eiffel-intelligence-frontend",\
                              "EI Backend GitHub": "https://github.com/eiffel-community/eiffel-intelligence",\
                              "Eiffel Github main page": "https://github.com/eiffel-community/eiffel",\
-                             "Test Rules User Guide": "https://github.com/eiffel-community/eiffel-intelligence/wiki/TestRulesUserGuide" }
+                             "Test Rules User Guide": "https://github.com/eiffel-community/eiffel-intelligence/blob/master/wiki/TestRulesUserGuide.md" }
 
 #### LOGGING #########
 logging.level.root: INFO

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -9,7 +9,7 @@ body {
     height: 100%;
 }
 #table {
-    cellspacing: 0px;
+    border-spacing: 0px;
 }
 .modal-subscription {
     max-width: 650px;
@@ -31,12 +31,6 @@ body {
 }
 .split {
 	max-width: 50%;
-}
-@media (max-width: 576px) {
-    .split {
-        max-width: 100%;
-        width: 100%;
-    }
 }
 .table-responsive>.table-bordered {
     border: 1px solid #dee2e6;
@@ -79,7 +73,11 @@ body {
 }
 
 .cursor-pointer {
-	cursor: pointer;
+    cursor: pointer;
+}
+.tooltip-inner {
+    text-align: left;
+    max-width: 410px;
 }
 .badge-rounded {
 	display: inline-block;
@@ -115,6 +113,63 @@ body {
 	position: absolute;
 	left: -999em;
 }
+
+/* The switch - the box around the slider */
+.switch {
+    position: relative;
+    display: inline-block;
+    width: 43px;
+    height: 23px;
+    margin-left: 5px;
+}
+/* Hide default HTML checkbox */
+.switch input {
+    opacity: 0;
+    width: 0;
+    height: 0;
+}
+/* The slider */
+.slider {
+    position: absolute;
+    cursor: pointer;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: #ccc;
+    -webkit-transition: .3s;
+    transition: .3s;
+}
+.slider:before {
+    position: absolute;
+    content: "";
+    height: 17px;
+    width: 17px;
+    left: 4px;
+    bottom: 3px;
+    background-color: white;
+    -webkit-transition: .3s;
+    transition: .3s;
+}
+input:checked + .slider {
+    background-color: #2196F3;
+}
+input:focus + .slider {
+    box-shadow: 0 0 1px #2196F3;
+}
+input:checked + .slider:before {
+    -webkit-transform: translateX(16px);
+    -ms-transform: translateX(16px);
+    transform: translateX(16px);
+}
+/* Rounded sliders */
+.slider.round {
+    border-radius: 25px;
+}
+.slider.round:before {
+    border-radius: 50%;
+}
+
 /* Safari */
 @-webkit-keyframes spin {
     0% { -webkit-transform: rotate(0deg); }
@@ -124,11 +179,16 @@ body {
     0% { transform: rotate(0deg); }
     100% { transform: rotate(360deg); }
 }
+
 @media (max-width: 576px) {
 	body {
         padding-top: 80px;
     }
     .container {
         max-width: 480px;
+    }
+    .split {
+        max-width: 100%;
+        width: 100%;
     }
 }

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -21,7 +21,8 @@ body {
 	width: 25rem;
 }
 .rule-button {
-    width: 150px;
+    width: auto;
+    min-width: 150px;
 }
 .display-inline-table {
     display: inline-table;

--- a/src/main/resources/static/js/main.js
+++ b/src/main/resources/static/js/main.js
@@ -12,117 +12,117 @@ jQuery(document).ready(function() {
         };
     }(jQuery));
     $("#selectInstances").visible();
-	// Fetch injected URL from DOM
-	var eiffelDocumentationUrlLinks = $('#eiffelDocumentationUrlLinks').text();
-	var frontendServiceUrl = $('#frontendServiceUrl').text();
-	var frontendServiceBackEndPath = "/backend";
+    // Fetch injected URL from DOM
+    var eiffelDocumentationUrlLinks = $('#eiffelDocumentationUrlLinks').text();
+    var frontendServiceUrl = $('#frontendServiceUrl').text();
+    var frontendServiceBackEndPath = "/backend";
 
-	function loadMainPage() {
-		updateBackEndInstanceList();
-		$("#navbarResponsive").removeClass("show");
-	    $("#selectInstances").visible();
-		$("#mainFrame").load("subscriptionpage.html");
-	}
+    function loadMainPage() {
+        updateBackEndInstanceList();
+        $("#navbarResponsive").removeClass("show");
+        $("#selectInstances").visible();
+        $("#mainFrame").load("subscriptionpage.html");
+    }
 
-	$("#testRulesBtn").click(function() {
-		updateBackEndInstanceList();
-		$("#navbarResponsive").removeClass("show");
-	    $("#selectInstances").visible();
-		$("#mainFrame").load("testRules.html");
-	});
+    $("#testRulesBtn").click(function() {
+        updateBackEndInstanceList();
+        $("#navbarResponsive").removeClass("show");
+        $("#selectInstances").visible();
+        $("#mainFrame").load("testRules.html");
+    });
 
-	$("#eiInfoBtn").click(function() {
-		updateBackEndInstanceList();
-		$("#navbarResponsive").removeClass("show");
-	    $("#selectInstances").visible();
-		$("#mainFrame").load("eiInfo.html");
-	});
+    $("#eiInfoBtn").click(function() {
+        updateBackEndInstanceList();
+        $("#navbarResponsive").removeClass("show");
+        $("#selectInstances").visible();
+        $("#mainFrame").load("eiInfo.html");
+    });
 
-	$("#loginBtn").click(function() {
-		$("#navbarResponsive").removeClass("show");
-	    $("#selectInstances").visible();
-		$("#mainFrame").load("login.html");
-	});
+    $("#loginBtn").click(function() {
+        $("#navbarResponsive").removeClass("show");
+        $("#selectInstances").visible();
+        $("#mainFrame").load("login.html");
+    });
 
-	$("#addInstanceBtn").click(function() {
-		$("#navbarResponsive").removeClass("show");
-	    $("#selectInstances").invisible();
-      	$("#mainFrame").load("add-instances.html");
+    $("#addInstanceBtn").click(function() {
+        $("#navbarResponsive").removeClass("show");
+        $("#selectInstances").invisible();
+          $("#mainFrame").load("add-instances.html");
     });
 
     $("#switcherBtn").click(function() {
-		$("#navbarResponsive").removeClass("show");
+        $("#navbarResponsive").removeClass("show");
         $("#selectInstances").invisible();
-      	$("#mainFrame").load("switch-backend.html");
+          $("#mainFrame").load("switch-backend.html");
     });
 
-	$("#logoutBtn").click(function() {
-		$("#navbarResponsive").removeClass("show");
-	    $("#selectInstances").visible();
-		$.ajax({
-			url : frontendServiceUrl + "/auth/logout",
-			type : "GET",
-			contentType : 'application/json; charset=utf-8',
-			cache: false,
-			complete : function (XMLHttpRequest, textStatus) {
-				doIfUserLoggedOut();
-				loadMainPage();
-			}
-		});
-	});
+    $("#logoutBtn").click(function() {
+        $("#navbarResponsive").removeClass("show");
+        $("#selectInstances").visible();
+        $.ajax({
+            url : frontendServiceUrl + "/auth/logout",
+            type : "GET",
+            contentType : 'application/json; charset=utf-8',
+            cache: false,
+            complete : function (XMLHttpRequest, textStatus) {
+                doIfUserLoggedOut();
+                loadMainPage();
+            }
+        });
+    });
 
-	$("#subscriptionBtn").click(function() {
-		loadMainPage();
-	});
+    $("#subscriptionBtn").click(function() {
+        loadMainPage();
+    });
 
-	$("#jmesPathRulesSetUpBtn").click(function() {
-		$("#navbarResponsive").removeClass("show");
-	    $("#selectInstances").visible();
-		$("#mainFrame").load("jmesPathRulesSetUp.html");
-	});
+    $("#jmesPathRulesSetUpBtn").click(function() {
+        $("#navbarResponsive").removeClass("show");
+        $("#selectInstances").visible();
+        $("#mainFrame").load("jmesPathRulesSetUp.html");
+    });
 
-	function doIfUserLoggedOut() {
-		localStorage.removeItem("currentUser");
-		$("#ldapUserName").text("Guest");
-		$("#loginBlock").show();
-		$("#logoutBlock").hide();
-		localStorage.setItem('errorsStore', []);
-	}
+    function doIfUserLoggedOut() {
+        localStorage.removeItem("currentUser");
+        $("#ldapUserName").text("Guest");
+        $("#loginBlock").show();
+        $("#logoutBlock").hide();
+        localStorage.setItem('errorsStore', []);
+    }
 
-	function loadDocumentLinks(){
-		// eiffelDocumentationUrlLinks variable is configure in application.properties
-		var linksList = JSON.parse(eiffelDocumentationUrlLinks);
-		var docLinksDoc = document.getElementById('collapseDocPages');
-		var liTag = null;
-		var aTag = null;
+    function loadDocumentLinks(){
+        // eiffelDocumentationUrlLinks variable is configure in application.properties
+        var linksList = JSON.parse(eiffelDocumentationUrlLinks);
+        var docLinksDoc = document.getElementById('collapseDocPages');
+        var liTag = null;
+        var aTag = null;
 
-		Object.keys(linksList).forEach(function(linkKey) {
-			liTag = document.createElement('li');
-			aTag = document.createElement('a');
-			aTag.innerHTML = linkKey;
-			aTag.setAttribute('href', linksList[linkKey]);
-			aTag.setAttribute('target', '_blanc');
-			liTag.appendChild(aTag);
-			docLinksDoc.appendChild(liTag);
-		});
-	}
+        Object.keys(linksList).forEach(function(linkKey) {
+            liTag = document.createElement('li');
+            aTag = document.createElement('a');
+            aTag.innerHTML = linkKey;
+            aTag.setAttribute('href', linksList[linkKey]);
+            aTag.setAttribute('target', '_blanc');
+            liTag.appendChild(aTag);
+            docLinksDoc.appendChild(liTag);
+        });
+    }
 
-	var initOneTime = function(){
-		initOneTime = function(){}; // kill it as soon as it was called
-		loadDocumentLinks();
-		loadMainPage();
-	};
+    var initOneTime = function(){
+        initOneTime = function(){}; // kill it as soon as it was called
+        loadDocumentLinks();
+        loadMainPage();
+    };
 
-	initOneTime();
+    initOneTime();
 
     function singleInstanceModel(name, host, port, path, https, active) {
-    	this.name = ko.observable(name),
-    	this.host = ko.observable(host),
-    	this.port = ko.observable(port),
-    	this.path = ko.observable(path),
-    	this.https = ko.observable(https),
+        this.name = ko.observable(name),
+        this.host = ko.observable(host),
+        this.port = ko.observable(port),
+        this.path = ko.observable(path),
+        this.https = ko.observable(https),
         this.active = ko.observable(active),
-	    this.information = name.toUpperCase() + " - " + host + " " + port + "/" + path;
+        this.information = name.toUpperCase() + " - " + host + " " + port + "/" + path;
     }
 
     function viewModel(data) {
@@ -130,57 +130,58 @@ jQuery(document).ready(function() {
         var currentName;
         self.instances = ko.observableArray();
         var json = JSON.parse(ko.toJSON(data));
+        var oldSelectedActive = self.selectedActive;
         for(var i = 0; i < json.length; i++) {
             var obj = json[i];
-        	var instance = new singleInstanceModel(obj.name, obj.host, obj.port, obj.path, obj.https, obj.active);
-        	self.instances.push(instance);
-        	if(obj.active == true){
-        	    currentName = obj.name;
-        	}
+            var instance = new singleInstanceModel(obj.name, obj.host, obj.port, obj.path, obj.https, obj.active);
+            self.instances.push(instance);
+            if(obj.active == true){
+                currentName = obj.name;
+            }
         }
         self.selectedActive = ko.observable(currentName);
         self.onChange = function(){
             if(typeof self.selectedActive() !== "undefined"){
                 $.ajax({
                     url: frontendServiceUrl + frontendServiceBackEndPath,
-            	    type: "PUT",
-            	    data: self.selectedActive(),
-            	    contentType: 'application/json; charset=utf-8',
-            	    cache: false,
-            	    error: function (XMLHttpRequest, textStatus, errorThrown) {
-            	        window.logMessages(XMLHttpRequest.responseText);
-            	    },
-            	    success: function (responseData, XMLHttpRequest, textStatus) {
-						console.log("Response from IE front end back end: " + responseData.message);
-						$.jGrowl(responseData.message, {sticky: false, theme: 'Notify'});
-						$("#navbarResponsive").removeClass("show");
-						$("#selectInstances").visible();
-						$("#mainFrame").load("subscriptionpage.html");
-            	    }
+                    type: "PUT",
+                    data: self.selectedActive(),
+                    contentType: 'application/json; charset=utf-8',
+                    cache: false,
+                    error: function (XMLHttpRequest, textStatus, errorThrown) {
+                        self.selectedActive = oldSelectedActive;
+                        updateBackEndInstanceList();
+                        window.logMessages(XMLHttpRequest.responseText);
+                    },
+                    success: function (responseData, XMLHttpRequest, textStatus) {
+                        console.log("Response from IE front end back end: " + responseData.message);
+                        location.reload();
+                    }
                 });
             } else {
                 $.jGrowl("Please chose backend instance", {sticky: false, theme: 'Error'});
               }
         }
-	}
-	function updateBackEndInstanceList() {
-		$.ajax({
-			url: frontendServiceUrl + frontendServiceBackEndPath,
-			type: "GET",
-			contentType: 'application/json; charset=utf-8',
-			cache: false,
-			error: function (XMLHttpRequest, textStatus, errorThrown) {
-				window.logMessages("Failure when trying to load backend instances");
-			},
-			success: function (responseData, XMLHttpRequest, textStatus) {
-				var observableObject = $("#selectInstances")[0];
-				ko.cleanNode(observableObject);
-				ko.applyBindings(new viewModel(responseData),observableObject);
-			}
-		});
-	}
+    }
 
-	$('body').on('click', function (e) {
+    function updateBackEndInstanceList() {
+        $.ajax({
+            url: frontendServiceUrl + frontendServiceBackEndPath,
+            type: "GET",
+            contentType: 'application/json; charset=utf-8',
+            cache: false,
+            error: function (XMLHttpRequest, textStatus, errorThrown) {
+                window.logMessages("Failure when trying to load backend instances");
+            },
+            success: function (responseData, XMLHttpRequest, textStatus) {
+                var observableObject = $("#selectInstances")[0];
+                ko.cleanNode(observableObject);
+                ko.applyBindings(new viewModel(responseData),observableObject);
+            }
+        });
+    }
+
+    $('body').on('click', function (e) {
         if ($(e.target).data('toggle') !== 'tooltip' && $(e.target)[0].className !== 'tooltip-inner') {
             $('.tooltip').tooltip('hide');
         }

--- a/src/main/resources/static/js/subscription.js
+++ b/src/main/resources/static/js/subscription.js
@@ -257,9 +257,20 @@ jQuery(document).ready(function () {
         };
 
         self.getUTCDate = function (epochtime) {
-            var d = new Date(0); // The 0 there is the key, which sets the date to the epoch
-            d.setUTCMilliseconds(epochtime);
-            return d;  // Is now a date (in client time zone)
+            var date = new Date(epochtime);
+            var resolvedOptions = Intl.DateTimeFormat().resolvedOptions();
+            var options = {
+                    year: 'numeric',
+                    month: 'short',
+                    day: 'numeric',
+                    hour: 'numeric',
+                    minute: 'numeric',
+                    second: 'numeric',
+                    hour12: false,
+                    timeZone: resolvedOptions.timeZone,
+                    timeZoneName: 'short'
+            };
+            return date.toLocaleDateString(resolvedOptions.locale, options);  // Is now a date (in client time zone)
         }
 
         self.add_requirement = function (data, event) {

--- a/src/main/resources/static/js/subscription.js
+++ b/src/main/resources/static/js/subscription.js
@@ -100,41 +100,93 @@ jQuery(document).ready(function () {
 
     // /Start ## Knockout ####################################################
 
+    var lastPressedRestPostBodyMediaType = "";
     // Subscription model
     function subscription_model(data) {
-
         this.created = ko.observable(data.created);
-        this.notificationMeta = ko.observable(data.notificationMeta);
+        this.notificationMeta = ko.observable(data.notificationMeta).extend({ notify: 'always' });
         this.notificationType = ko.observable(data.notificationType);
         this.restPostBodyMediaType = ko.observable(data.restPostBodyMediaType);
         this.notificationMessageKeyValues = ko.observableArray(data.notificationMessageKeyValues);
         this.notificationMessageKeyValuesAuth = ko.observableArray(data.notificationMessageKeyValuesAuth);
         this.repeat = ko.observable(data.repeat);
         this.requirements = ko.observableArray(data.requirements);
-        this.subscriptionName = ko.observable(data.subscriptionName);
+        this.subscriptionName = ko.observable(data.subscriptionName).extend({ notify: 'always' });
         this.aggregationtype = ko.observable(data.aggregationtype);
         this.authenticationType = ko.observable(data.authenticationType);
         this.userName = ko.observable(data.userName);
         this.password = ko.observable(data.password);
 
-        this.notificationType.subscribe(function (new_value) {
-            vm.subscription()[0].restPostBodyMediaType(null);
+        // Default to REST_POST
+        if (this.notificationType() == "" || this.notificationType() == null) {
+            this.notificationType = ko.observable("REST_POST");
+        }
+
+        if (this.notificationType() == "REST_POST") {
+            vm.restPost(true);
+        } else {
+            vm.restPost(false);
+        }
+
+        // Default to Repeat off
+        if (this.repeat() == "" || this.repeat() == null || this.repeat == undefined) {
+            this.repeat = ko.observable(false);
+        }
+
+        // Default to RAW BODY
+        if (this.restPostBodyMediaType() == "application/x-www-form-urlencoded") {
+            vm.formpostkeyvaluepairs(true);
+        } else {
+            this.restPostBodyMediaType = ko.observable("application/json");
             vm.formpostkeyvaluepairs(false);
+        }
 
-        });
+        // Subscribe START
+        // Subscribe notificationType
+        this.notificationType.subscribe(function (new_value) {
+            $('#invalidNotificationMeta').hide();
+            vm.formpostkeyvaluepairs(false);
+            if (new_value == "REST_POST") {
+                vm.restPost(true);
+                if (lastPressedRestPostBodyMediaType == "application/x-www-form-urlencoded") {
+                    vm.formpostkeyvaluepairs(true);
+                }
+            } else {
+                vm.restPost(false);
+            }
+            var allowEmpty = true;
+            validateNotificationMeta(this.notificationMeta(), allowEmpty);
+        }, this);
 
+        // Subscribe restPostBodyMediaType
         this.restPostBodyMediaType.subscribe(function (new_value) {
+            // Remember last restPostMediaType, when switching from MAIL we get back to the last used.
+            lastPressedRestPostBodyMediaType = new_value;
             if (new_value == "application/x-www-form-urlencoded") {
                 vm.formpostkeyvaluepairs(true);
             } else {
                 vm.formpostkeyvaluepairs(false);
             }
+        }, this);
+
+        // Subscribe subscriptionName
+        this.subscriptionName.subscribe(function (name_input) {
+            validateName(name_input);
         });
+
+        this.notificationMeta.subscribe(function (notificationMeta) {
+            var allowEmpty = false;
+            validateNotificationMeta(notificationMeta, allowEmpty);
+        });
+        // Subscribe END
     }
 
     function formdata_model(formdata) {
         this.formkey = ko.observable(formdata.formkey);
         this.formvalue = ko.observable(formdata.formvalue);
+        this.formvalue.subscribe(function (newText) {
+            // TODO implement form data check.
+         });
     }
 
     function conditions_model(condition) {
@@ -149,14 +201,14 @@ jQuery(document).ready(function () {
     var SubscriptionViewModel = function () {
         var self = this;
         self.subscription = ko.observableArray([]);
-        self.subscription_templates_in = ko.observableArray(
-            [
+        self.subscription_templates_in = ko.observableArray([
                 { "text": "Jenkins Pipeline Parameterized Job Trigger", value: "templatejenkinsPipelineParameterizedBuildTrigger" },
                 { "text": "REST POST (Raw Body : JSON)", value: "templateRestPostJsonRAWBodyTrigger" },
                 { "text": "Mail Trigger", value: "templateEmailTrigger" }
             ]);
         self.choosen_subscription_template = ko.observable();
         self.authenticationType = ko.observable();
+        self.restPost = ko.observable(false);
         self.formpostkeyvaluepairs = ko.observable(false);
         self.mode = ko.observable("");
         self.showPassword = ko.observable(false);
@@ -164,25 +216,34 @@ jQuery(document).ready(function () {
             self.showPassword(boolean);
         }
         self.formpostkeyvaluepairsAuth = ko.observable(false);
-        self.notificationType_in = ko.observableArray(
-            [
-                { "text": "REST_POST", value: "REST_POST" },
-                { "text": "MAIL", value: "MAIL" }
+        self.notificationType_in = ko.observableArray([
+                {"value": "REST_POST", "label": "REST_POST", "id": "restPostRadio"},
+                {"value": "MAIL", "label": "MAIL", "id": "mailRadio"}
             ]);
-        self.authenticationType_in = ko.observableArray(
-            [
+        self.restPostBodyMediaType_in = ko.observableArray([
+                {"value": "application/x-www-form-urlencoded", "label": "FORM/POST Parameters", "id": "keyValueRadio"},
+                {"value": "application/json", "label": "RAW BODY: JSON",  "id": "appJsonRadio"}
+            ]);
+        self.authenticationType_in = ko.observableArray([
                 { "text": "NO_AUTH", value: "NO_AUTH" },
                 { "text": "BASIC_AUTH", value: "BASIC_AUTH" }
             ]);
-
-
-        self.restPostBodyType_in = ko.observableArray(
-            [
-                { "text": "FORM/POST Parameters (application/x-www-form-urlencoded)", value: "application/x-www-form-urlencoded" },
-                { "text": "RAW BODY: JSON (application/json)", value: "application/json" }
+        self.repeat_in = ko.observableArray([
+                { "value": true, "label": "Activate Repeat" }
             ]);
 
-        self.repeat_in = ko.observableArray([true, false]);
+        self.add_requirement = function (data, event) {
+            var conditions_array = [];
+            conditions_array.push(new jmespath_model({ "jmespath": ko.observable("") }));
+            self.subscription()[0].requirements().push(new conditions_model(conditions_array));
+
+            // Force update
+            var data = self.subscription().slice(0);
+            self.subscription([]);
+            self.subscription(data);
+            self.subscription.valueHasMutated();
+            loadTooltip();
+        };
 
         self.choosen_subscription_template.subscribe(function (template_var) {
             if (self.choosen_subscription_template() != null) { // only execute if value exists
@@ -316,7 +377,7 @@ jQuery(document).ready(function () {
             {
                 "targets": [2],
                 "orderable": true,
-                "title": "UserName",
+                "title": "Owner",
                 "data": "ldapUserName",
                 "defaultContent": ""
             },
@@ -329,12 +390,6 @@ jQuery(document).ready(function () {
             {
                 "targets": [4],
                 "orderable": true,
-                "title": "Type",
-                "data": "aggregationtype"
-            },
-            {
-                "targets": [5],
-                "orderable": true,
                 "title": "Date",
                 "data": "created",
                 "mRender": function (data, type, row, meta) {
@@ -342,25 +397,25 @@ jQuery(document).ready(function () {
                 }
             },
             {
-                "targets": [6],
+                "targets": [5],
                 "orderable": true,
                 "title": "NotificationType",
                 "data": "notificationType"
             },
             {
-                "targets": [7],
+                "targets": [6],
                 "orderable": true,
                 "title": "NotificationMeta",
                 "data": "notificationMeta"
             },
             {
-                "targets": [8],
+                "targets": [7],
                 "orderable": true,
                 "title": "Repeat",
                 "data": "repeat"
             },
             {
-                "targets": [9],
+                "targets": [8],
                 "className": "sub-action-column",
                 "orderable": false,
                 "title": "Action",
@@ -385,9 +440,9 @@ jQuery(document).ready(function () {
     });
 
     $("#sidenavCollapse").click(function() {
-		table.responsive.rebuild();
+        table.responsive.rebuild();
         table.responsive.recalc();
-	});
+    });
     // /Stop ## Datatables ##################################################
 
     // /Start ## check all subscriptions ####################################
@@ -406,7 +461,7 @@ jQuery(document).ready(function () {
 
     // /Start ## Reload Table################################################
     $("#reloadButton").click(function () {
-    	reload_table();
+        reload_table();
     });
     // /Stop ## Reload Table#################################################
 
@@ -666,6 +721,7 @@ jQuery(document).ready(function () {
             vm.subscription(mappedPackageInfo);
             // Force update
             vm.subscription()[0].restPostBodyMediaType.valueHasMutated();
+            loadTooltip();
             $('#modal_form').modal('show');
             if (save_method_in === "edit") {
                 title_ = 'Edit Subscription';
@@ -680,9 +736,6 @@ jQuery(document).ready(function () {
             }
             $('.modal-title').text(title_);
             save_method = save_method_in;
-            $('#modal_form').on('shown.bs.modal', function() {
-            	loadTooltip();
-            });
             $('#modal_form').on('hidden.bs.modal', function() {
                 $('.text-danger').hide();
             });
@@ -701,6 +754,59 @@ jQuery(document).ready(function () {
     }
     // /Stop ## pupulate JSON  ###########################################
 
+    function validateName(subscriptionName) {
+        var error = false;
+        $('#invalidSubscriptionName').hide();
+        $('#subscriptionNameInput').removeClass("is-invalid");
+
+        // Validate SubscriptionName field
+        if (subscriptionName == "") {
+            $('#invalidSubscriptionName').text("SubscriptionName must not be empty");
+            $('#subscriptionNameInput').addClass("is-invalid");
+            error = true;
+        }
+
+        // /(\W)/ Is a regex that matches anything that is not [A-Z,a-z,0-8] and _.
+        var regExpression = /(\W)/g;
+        if ((regExpression.test(subscriptionName))) {
+            var invalidLetters = subscriptionName.match(regExpression);
+            console.log("Invalid characters: [" + invalidLetters + "].")
+            $('#invalidSubscriptionName').text(
+                "Only letters, numbers and underscore allowed! "
+                + "Invalid characters: [" + invalidLetters + "]");
+            $('#subscriptionNameInput').addClass("is-invalid");
+            error = true;
+        }
+        if (error) {
+            $('#invalidSubscriptionName').show();
+        }
+        return error;
+    }
+
+    function validateNotificationMeta(notificationMeta, allowEmpty) {
+        var error = false;
+        $('#invalidNotificationMeta').hide();
+        $('#notificationMeta').removeClass("is-invalid");
+
+        if (!allowEmpty && notificationMeta == "") {
+            $('#invalidNotificationMeta').text("NotificationMeta must not be empty");
+            error = true;
+        } else if (vm.restPost()) {
+            //validate url not implemented yet.
+        } else if (!vm.restPost()) {
+            // Validate email
+            var regExpression = /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
+            if (!regExpression.test(notificationMeta) && notificationMeta != "") {
+                $('#invalidNotificationMeta').text("Not a valid email.");
+                $('#notificationMeta').addClass("is-invalid");
+                error = true;
+            }
+        }
+        if (error) {
+            $('#invalidNotificationMeta').show();
+        }
+        return error;
+    }
 
     // /Start ## Save Subscription ##########################################
     $('div.modal-footer').on('click', 'button.save_record', function (event) {
@@ -713,53 +819,16 @@ jQuery(document).ready(function () {
         }
 
         $('.text-danger').hide();
-        //START: Make sure all datatables field has a value
-        var subscriptionName = String(vm.subscription()[0].subscriptionName());
-        // Validate SubscriptionName field
-        if (subscriptionName == "") {
-            window.logMessages("Error: SubscriptionName field must have a value");
-            $('#noNameGiven').text("SubscriptionName must not be empty");
-            $('#noNameGiven').show();
+
+        // Validate subscription name field
+        if (validateName(String(vm.subscription()[0].subscriptionName()))) {
             error = true;
         }
 
-        // /(\W)/ Is a regex that matches anything that is not [A-Z,a-z,0-8] and _.
-        var regExpression = /(\W)/g;
-        if ((regExpression.test(subscriptionName))) {
-            var invalidLetters = subscriptionName.match(regExpression);
-            console.log("Invalid characters: [" + invalidLetters + "].")
-            window.logMessages(
-                "Only numbers,letters and underscore is valid to type in subscriptionName "
-                + " field. \nInvalid letters [" + invalidLetters + "].");
-            $('#invalidLetters').text(
-                "Only letters, numbers and underscore allowed! "
-                + "\nInvalid characters: [" + invalidLetters + "]");
-            $('#invalidLetters').show();
-            error = true;
-        }
-
-        // Validate notificationType field
-        if (vm.subscription()[0].notificationType() == null) {
-            window.logMessages("Error: notificationType value needs to be set");
-            $('#notificationTypeNotSet').text("> NotificationType must be set");
-            $('#notificationTypeNotSet').show();
-            error = true;
-        }
         // Validate notificationMeta field
-        if (vm.subscription()[0].notificationMeta() == "") {
-            window.logMessages("Error: notificationMeta field must have a value");
-            $('#noNotificationMetaGiven').text("NotificationMeta must not be empty");
-            $('#noNotificationMetaGiven').show();
+        if (validateNotificationMeta(String(vm.subscription()[0].notificationMeta()))) {
             error = true;
         }
-        // Validate repeat field
-        if (vm.subscription()[0].repeat() == null) {
-            window.logMessages("Error: repeat field must be selected true or false");
-            $('#repeatNotSet').text("> Repeat must be set");
-            $('#repeatNotSet').show();
-            error = true;
-        }
-        //END OF: Make sure all datatables field has a value
 
         //START: Check of other subscription fields values
         for (i = 0; i < notificationMessageKeyValuesArray.length; i++) {
@@ -767,7 +836,6 @@ jQuery(document).ready(function () {
             var test_value = ko.toJSON(notificationMessageKeyValuesArray[i].formvalue());
             if (vm.formpostkeyvaluepairs()) {
                 if (test_key.replace(/\s/g, "") === '""' || test_value.replace(/\s/g, "") === '""') {
-                    window.logMessages("Error: Value & Key  in notificationMessage must have a values!");
                     $('#noNotificationKeyOrValue').text("NotificationMessage key and or values must be set");
                     $('#noNotificationKeyOrValue').show();
                     error = true;
@@ -775,19 +843,16 @@ jQuery(document).ready(function () {
             }
             else {
                 if (notificationMessageKeyValuesArray.length !== 1) {
-                    window.logMessages("Error: Only one array is allowed for notificationMessage when NOT using key/value pairs!");
                     $('#notificationMessageKeyValuesArrayToLarge').text("Only one array is allowed for notificationMessage when NOT using key/value pairs");
                     $('#notificationMessageKeyValuesArrayToLarge').show();
                     error = true;
                 }
                 else if (test_key !== '""') {
-                    window.logMessages("Error: Key in notificationMessage must be empty when NOT using key/value pairs!");
                     $('#keyInNotificationMessage').text("Key in notificationMessage must be empty when NOT using key/value pairs");
                     $('#keyInNotificationMessage').show();
                     error = true;
                 }
                 else if (test_value.replace(/\s/g, "") === '""') {
-                    window.logMessages("Error: Value in notificationMessage must have a value when NOT using key/value pairs!");
                     $('#noNotificationMessage').text("Value in notificationMessage must have a value when NOT using key/value pairs");
                     $('#noNotificationMessage').show();
                     error = true;
@@ -801,7 +866,6 @@ jQuery(document).ready(function () {
             for (k = 0; k < conditionsArray.length; k++) {
                 var conditionToTest = ko.toJSON(conditionsArray[k].jmespath());
                 if (conditionToTest === '""') {
-                    window.logMessages("Error: JMESPath field must have a value");
                     $('.emptyCondition').text("Condition must not be empty");
                     $('.emptyCondition').show();
                     error = true;
@@ -816,8 +880,6 @@ jQuery(document).ready(function () {
         }
         //END: Check of other subscription fields values
 
-        var id = ko.toJSON(vm.subscription()[0].subscriptionName).trim();
-
         var url;
         var type;
         if (save_method === 'add') {  // Add new
@@ -828,7 +890,10 @@ jQuery(document).ready(function () {
             url = frontendServiceUrl + "/subscriptions";
             type = "PUT";
         }
-
+        // Ensure MAIL notificationType has no restPostBodyMediaType
+        if (vm.subscription()[0].notificationType() == "MAIL") {
+            vm.subscription()[0].restPostBodyMediaType("");
+        }
 
         // AJAX Callback handling
         var callback = {
@@ -921,6 +986,6 @@ jQuery(document).ready(function () {
     }
 
     function closeTooltip() {
-    	$('.tooltip').tooltip('hide');
+        $('.tooltip').tooltip('hide');
     }
 });

--- a/src/main/resources/static/js/switch-instances.js
+++ b/src/main/resources/static/js/switch-instances.js
@@ -3,31 +3,31 @@ var frontendServiceUrl = $('#frontendServiceUrl').text();
 var frontendServiceBackEndPath = "/backend";
 var sendbtn = document.getElementById('switcher').disabled = true;
 function singleInstanceModel(name, host, port, path, https, active) {
-	this.name = ko.observable(name),
-	this.host = ko.observable(host),
-	this.port = ko.observable(port),
-	this.path = ko.observable(path),
-	this.https = ko.observable(https),
-	this.active = ko.observable(active)
+    this.name = ko.observable(name),
+    this.host = ko.observable(host),
+    this.port = ko.observable(port),
+    this.path = ko.observable(path),
+    this.https = ko.observable(https),
+    this.active = ko.observable(active)
 }
 function multipleInstancesModel(data) {
-	var self = this;
-	var selected;
-	self.instances = ko.observableArray();
-	var json = JSON.parse(ko.toJSON(data));
-	for(var i = 0; i < json.length; i++) {
-		var obj = json[i];
-		var instance = new singleInstanceModel(obj.name, obj.host, obj.port, obj.path, obj.https, obj.active);
-		self.instances.push(instance);
-	}
-	self.checked = function(){
-	    var sendbtn = document.getElementById('switcher').disabled = false;
+    var self = this;
+    var selected;
+    self.instances = ko.observableArray();
+    var json = JSON.parse(ko.toJSON(data));
+    for(var i = 0; i < json.length; i++) {
+        var obj = json[i];
+        var instance = new singleInstanceModel(obj.name, obj.host, obj.port, obj.path, obj.https, obj.active);
+        self.instances.push(instance);
+    }
+    self.checked = function(){
+        var sendbtn = document.getElementById('switcher').disabled = false;
         selected = JSON.parse(ko.toJSON(this));
-	    return true;
-	}
-	self.removeInstance = function() {
-		self.instances.remove(this);
-    	$.ajax({
+        return true;
+    }
+    self.removeInstance = function() {
+        self.instances.remove(this);
+        $.ajax({
             url: frontendServiceUrl + frontendServiceBackEndPath,
             type: "DELETE",
             data: ko.toJSON(this),
@@ -40,54 +40,36 @@ function multipleInstancesModel(data) {
                 $.jGrowl(responseData.message, {sticky: false, theme: 'Notify'});
             }
         });
-	}
-	self.submit = function(instances) {
-	    var json = JSON.parse(ko.toJSON(instances));
-	    self.instances.removeAll();
-	    for(var i = 0; i < json.length; i++){
-	        var obj = json[i];
-	        if(obj.active == true &&
-	            !(obj.name == selected.name && obj.host == selected.host && obj.port == selected.port && obj.path == selected.path)){
-	            obj.active = false;
-	        }
-	        var instance = new singleInstanceModel(obj.name, obj.host, obj.port, obj.path, obj.https, obj.active);
-            self.instances.push(instance);
-	    }
-		$.ajax({
-		    url: frontendServiceUrl + frontendServiceBackEndPath,
-			type: "PUT",
-			data: ko.toJSON(self.instances),
-			contentType: 'application/json; charset=utf-8',
-			cache: false,
-			error: function (XMLHttpRequest, textStatus, errorThrown) {
-			    window.logMessages(XMLHttpRequest.responseText);
-			},
-			success: function (responseData, XMLHttpRequest, textStatus) {
-				console.log("Response from IE front end back end: " + responseData.message);
-				$.getScript( "js/main.js" )
-					.done(function( script, textStatus ) {
-					updateBackEndInstanceList();
-				});
-				$.jGrowl(responseData.message, {sticky: false, theme: 'Notify'});
-				$("#navbarResponsive").removeClass("show");
-				$("#selectInstances").visible();
-				$("#mainFrame").load("subscriptionpage.html");
-			}
-	    });
-	}
+    }
+    self.submit = function() {
+        $.ajax({
+            url: frontendServiceUrl + frontendServiceBackEndPath,
+            type: "PUT",
+            data: selected.name,
+            contentType: 'application/json; charset=utf-8',
+            cache: false,
+            error: function (XMLHttpRequest, textStatus, errorThrown) {
+                window.logMessages(XMLHttpRequest.responseText);
+            },
+            success: function (responseData, XMLHttpRequest, textStatus) {
+                console.log("Response from IE front end back end: " + responseData.message);
+                location.reload();
+            }
+        });
+    }
 }
 $.ajax({
-	url: frontendServiceUrl + frontendServiceBackEndPath,
-	type: "GET",
-	contentType: 'application/json; charset=utf-8',
-	cache: false,
-	error: function (XMLHttpRequest, textStatus, errorThrown) {
-	    window.logMessages("Failure when trying to load backend instances");
-	},
-	success: function (responseData, XMLHttpRequest, textStatus) {
-		var observableObject = $("#instancesModel")[0];
+    url: frontendServiceUrl + frontendServiceBackEndPath,
+    type: "GET",
+    contentType: 'application/json; charset=utf-8',
+    cache: false,
+    error: function (XMLHttpRequest, textStatus, errorThrown) {
+        window.logMessages("Failure when trying to load backend instances");
+    },
+    success: function (responseData, XMLHttpRequest, textStatus) {
+        var observableObject = $("#instancesModel")[0];
         ko.cleanNode(observableObject);
         ko.applyBindings(new multipleInstancesModel(responseData), observableObject);
-	}
+    }
 })
 });

--- a/src/main/resources/static/js/testrules.js
+++ b/src/main/resources/static/js/testrules.js
@@ -1,6 +1,7 @@
 // Global vars
 var frontendServiceUrl;
 var i = 0;
+var isReplacing = true;
 var ruleTemplate = {
   "TemplateName" : "",
   "Type" : "",
@@ -189,91 +190,105 @@ jQuery(document).ready(
               sticky : false,
               theme : 'Notify'
             });
-            
+
             var list = JSON.parse(fileContent);
-            if (isRules == true) {
-                vm.rulesBindingList([]);
+            if (isRules) {
+                if (isReplacing) {
+                    vm.rulesBindingList([]);
+                }
                 list.forEach(function(element) {
                     vm.addRule(element);
                 });
             } else {
-                vm.eventsBindingList([]);
+                if (isReplacing) {
+                    vm.eventsBindingList([]);
+                }
                 list.forEach(function(element) {
                     vm.addEvent(element);
                 });
             }
           };
-          
+
           if (subscriptionFile != null){
             reader.readAsText(subscriptionFile);
           }
        }
 
-        //Set onchange event on the input element "uploadRulesFile" and "uploadEventsFile"
-        var pomRules = document.getElementById('uploadRulesFile');
-        pomRules.onchange = function uploadFinished() {
-            var subscriptionFile = pomRules.files[0];
-            validateJSONAndUpload(subscriptionFile, true);
-            $(this).val("");
-        };
-        
-        var pomEvents = document.getElementById('uploadEventsFile');
-        pomEvents.onchange = function uploadFinished() {
-            var subscriptionFile = pomEvents.files[0];
-            validateJSONAndUpload(subscriptionFile, false);
-            $(this).val("");
-        };
-          
+      //Set onchange event on the input element "uploadRulesFile" and "uploadEventsFile"
+      var pomRules = document.getElementById('uploadRulesFile');
+      pomRules.onchange = function uploadFinished() {
+        var subscriptionFile = pomRules.files[0];
+        validateJSONAndUpload(subscriptionFile, true);
+        $(this).val("");
+      };
+
+      var pomEvents = document.getElementById('uploadEventsFile');
+      pomEvents.onchange = function uploadFinished() {
+        var subscriptionFile = pomEvents.files[0];
+        validateJSONAndUpload(subscriptionFile, false);
+        $(this).val("");
+      };
+
       //Upload events list json data
       $(".container").on("click", "button.upload_rules", function(event) {
         event.stopPropagation();
         event.preventDefault();
+        var isRules = true;
+        replaceAppendModal(isRules);
 
-        function createRulesUploadWindow() {
-          if (document.createEvent) {
-            var event = document.createEvent('MouseEvents');
-            event.initEvent('click', true, true);
-            pomRules.dispatchEvent(event);
-          } else {
-            pomRules.click();
-          }
-        }
-        
-        function createUploadWindowMSExplorer() {
-          $('#upload_rules').click();
-          var file = $('#upload_rules').prop('files')[0];
-          validateJSONAndUpload(file, true);
-        }
-
-        // HTML5 Download File window handling
-        createRulesUploadWindow();
       });
 
-      //Upload list of events json data
+       //Upload list of events json data
       $(".container").on("click", "button.upload_events", function(event) {
         event.stopPropagation();
         event.preventDefault();
-
-        function createUploadWindow() {
-          if (document.createEvent) {
-            var event = document.createEvent('MouseEvents');
-            event.initEvent('click', true, true);
-            pomEvents.dispatchEvent(event);
-          } else {
-            pomEvents.click();
-          }
-        }
-
-        function createUploadWindowMSExplorer() {
-          $('#upload_events').click();
-          var file = $('#upload_events').prop('files')[0];
-          validateJSONAndUpload(file, false);
-        }
-
-
-        // HTML5 Download File window handling
-        createUploadWindow();
+        var isRules = false;
+        replaceAppendModal(isRules);
       });
+
+      function replaceAppendModal(isRules){
+        $('#AppendReplaceModal').modal('show');
+
+        document.getElementById('replaceButton').onclick = function(){
+            $('#AppendReplaceModal').modal('hide');
+            isReplacing = true;
+            if(isRules){
+                createRulesUploadWindow();
+            }else{
+                createUploadWindow();
+            }
+        };
+
+        document.getElementById('appendButton').onclick = function(){
+            $('#AppendReplaceModal').modal('hide');
+            isReplacing = false;
+            if(isRules){
+                createRulesUploadWindow();
+            }else{
+                createUploadWindow();
+            }
+        };
+      }
+
+     function createRulesUploadWindow() {
+        if (document.createEvent) {
+          var event = document.createEvent('MouseEvents');
+          event.initEvent('click', true, true);
+          pomRules.dispatchEvent(event);
+        } else {
+          pomRules.click();
+        }
+      }
+
+      function createUploadWindow() {
+        if (document.createEvent) {
+          var event = document.createEvent('MouseEvents');
+          event.initEvent('click', true, true);
+          pomEvents.dispatchEvent(event);
+        } else {
+          pomEvents.click();
+        }
+      }
 
       // Download the modified rule
       $('.container').on('click', 'button.download_rules', function() {

--- a/src/main/resources/static/js/testrules.js
+++ b/src/main/resources/static/js/testrules.js
@@ -152,6 +152,18 @@ jQuery(document).ready(
         self.addEvent = function(data) {
             self.eventsBindingList.push({'data': ko.observable(self.parsedToString(data))});
         };
+
+        // This function is used to remove all rules
+        self.clearAllRules = function(){
+            self.rulesBindingList([]);
+            self.addRule(ruleTemplate);
+        }
+
+	// This function is used to remove all events
+        self.clearAllEvents = function(){
+            self.eventsBindingList([]);
+            self.addEvent({});
+        }
         return self;
       }
 

--- a/src/main/resources/templates/subscription.html
+++ b/src/main/resources/templates/subscription.html
@@ -21,10 +21,10 @@
         </div>
         <div class="col-md-3 col-4 d-flex justify-content-end">
             <div id="btnEIContainer">
-	            <button title="EI connection status check is refreshed continuously. Click button to force check status."
-	                type="button" id="btnEIConnection" class="btn btnEIConnectionStatus white-space-normal">
-	                <i class="glyphicon"></i>EI Backend Status
-	            </button>
+                <button title="EI connection status check is refreshed continuously. Click button to force check status."
+                    type="button" id="btnEIConnection" class="btn btnEIConnectionStatus white-space-normal">
+                    <i class="glyphicon"></i>EI Backend Status
+                </button>
             </div>
         </div>
     </div>
@@ -89,20 +89,17 @@
                                                optionsText: 'text',
                                                optionsValue: 'value',
                                                value: choosen_subscription_template,
-                                               optionsCaption: 'Choose...'"></select>
+                                               optionsCaption: 'Select template to fill the fields.'"></select>
                                 </div>
                             </div>
-
 
                             <!-- ko foreach:  subscription -->
                             <div class="form-group">
                                 <label class="pl-1 control-label font-weight-bold">SubscriptionName</label>
                                 <div>
                                     <!-- text injected from subscription.js -->
-                                    <span class="text-danger font-small" id="invalidLetters"></span>
-                                    <span class="text-danger font-small" id="noNameGiven"></span>
-
-                                    <input id="subscriptionNameInput" data-bind="textInput:$data.subscriptionName"
+                                    <span class="text-danger font-small" id="invalidSubscriptionName"></span>
+                                    <input id="subscriptionNameInput" data-bind="textInput:$data.subscriptionName, onChange"
                                         name="subscriptionName" placeholder="subscriptionName" class="form-control display-inline-table" type="text"/>
                                     <span class="help-block"></span>
                                 </div>
@@ -115,6 +112,7 @@
                                     <span class="help-block"></span>
                                 </div>
                             </div>
+                            <!-- Type should be removed?
                             <div class="form-group" data-bind="visible: $data.aggregationtype()">
                                 <label class="pl-1 control-label font-weight-bold">Type</label>
                                 <div>
@@ -123,30 +121,39 @@
                                     <span class="help-block"></span>
                                 </div>
                             </div>
+                            -->
                             <div class="form-group">
                                 <label class="pl-1 control-label font-weight-bold">NotificationType</label>
-                                <img class="cursor-pointer" id="notificationTypeInfo" alt="NotificationType Info" src="assets/images/information.png"
-                                    title="This is the notification method used once the subscription triggers."/>
-                                <div>
-                                    <select id="notificationType" data-bind="options: $root.notificationType_in,
-                                               optionsText: 'text',
-                                               optionsValue: 'value',
-                                               value: $data.notificationType,
-                                               optionsCaption: 'Choose...'"></select>
-                                    <span class="text-danger font-small" id="notificationTypeNotSet"></span>
+                                <img class="cursor-pointer" id="notificationTypeInfo" alt="NotificationType Info" src="assets/images/information.png" data-toggle="tooltip" data-placement="top"
+                                    title="This is the notification method used when the subscription is triggered."/>
+
+                                <!-- Rest or Mail radio buttons -->
+                                <div id="notificationTypeRadio" data-bind="foreach: $root.notificationType_in" >
+                                    <label>
+                                        <input type="radio" name="restOrMailGroup" data-bind="
+                                                attr: {value: value, id: id}, checked: $parent.notificationType, onChange" />
+                                        <span data-bind="text: label"></span>
+                                    </label>
                                 </div>
                             </div>
 
-                            <div class="form-group" data-bind="visible: notificationType() == 'REST_POST'">
+                            <div class="form-group" data-bind="visible: $data.notificationType() == 'REST_POST'">
                                 <label class="pl-1 control-label font-weight-bold">RestPostMediaType</label>
-                                <img class="cursor-pointer" id="restPostMediaTypeInfo" alt="RestPostMediaType Info" src="assets/images/information.png"
-                                    title="This decides the Content-Type of the POST body."/>
-                                <div>
-                                    <select class="w-100" data-bind="options: $root.restPostBodyType_in,
-                                               optionsText: 'text',
-                                               optionsValue: 'value',
-                                               value: $data.restPostBodyMediaType,
-                                               optionsCaption: 'Choose...'"></select>
+                                <img class="cursor-pointer popup-large" id="restPostMediaTypeInfo" alt="RestPostMediaType Info" src="assets/images/information.png" data-toggle="tooltip" data-placement="top"
+                                    title=
+                                        "This decides the Content-Type of the POST body. <br>
+                                        Default is: <br>
+                                        RAW BODY: JSON (application/json) <br>
+                                        You may select: <br>
+                                        FORM/POST Parameters (application/x-www-form-urlencoded)" />
+
+                                <!-- Form post  radio buttons -->
+                                <div data-bind="foreach: $root.restPostBodyMediaType_in" >
+                                    <label>
+                                        <input type="radio" name="restPostBodyMediaTypeGroup" data-bind="
+                                                attr: {value: value, id: id}, checked: $parent.restPostBodyMediaType, onChange" />
+                                        <span data-bind="text: label"></span>
+                                    </label>
                                 </div>
                             </div>
 
@@ -164,42 +171,59 @@
                                 <div>
                                     <span class="text-danger font-small" id="noNotificationMessage"></span>
                                 </div>
-                                <table width="100%">
+                                <!-- Table for FORM/POST Parameters (application/x-www-form-urlencoded) -->
+                                <table width="100%" data-bind="visible: $root.formpostkeyvaluepairs()">
                                     <thead>
                                         <tr>
-                                            <th width="20%" data-bind="visible: $root.formpostkeyvaluepairs">Key</th>
-                                            <th width="70%">Value</th>
-                                            <th width="10%" data-bind="visible: $root.formpostkeyvaluepairs"></th>
+                                            <th width="20%">Key</th>
+                                            <th width="80%">Value</th>
                                         </tr>
                                     </thead>
                                     <tbody data-bind="foreach: notificationMessageKeyValues">
                                         <tr>
-                                            <td valign="top" data-bind="visible: $root.formpostkeyvaluepairs">
-                                                <input data-bind="textInput:$data.formkey" name="formkey" placeholder="Key" class="form-control"
+                                            <td valign="top">
+                                                <input data-bind="textInput:$data.formkey, onChange" name="formkey" placeholder="Key" class="form-control"
                                                     type="text" />
                                             </td>
                                             <td>
-                                                <textarea data-bind="textInput:$data.formvalue" name="formvalue"
+                                                <textarea data-bind="textInput:$data.formvalue, onChange" name="formvalue"
                                                     placeholder="Value" class="form-control" type="text"></textarea>
                                             </td>
-                                            <td valign="top" data-bind="visible: $root.formpostkeyvaluepairs">
-                                                <button data-bind="click: function(data, event) { $root.delete_NotificationMsgKeyValuePair(data, event, $index()); },
-                                                    style:{visibility:($root.subscription()[0].notificationMessageKeyValues().length > 1) ? 'visible' : 'hidden'}"
-                                                    class="btn btn-danger float-right" style="visibility:hidden">
-                                                    <i class="glyphicon glyphicon-trash"></i>Delete
+                                            <td data-bind="if: $root.subscription()[0].notificationMessageKeyValues().length > 1" valign="top" >
+                                                <button data-bind="click: function(data, event) {$root.delete_NotificationMsgKeyValuePair(data, event, $index());}"
+                                                    class="btn btn-danger float-rightmr-1 mr-1 mt-1 d-inline-block">
+                                                    <i class="fa fa-fw fa-trash"></i>
                                                 </button>
                                             </td>
                                         </tr>
                                     </tbody>
                                 </table>
-
-                                <div data-bind="visible: $root.formpostkeyvaluepairs" class="pt-1 d-flex justify-content-end">
-                                    <button id="kvID" data-bind="click: $root.addNotificationMsgKeyValuePair" class="btn btn-success">
-                                        <i class="glyphicon glyphicon-plus float-right"></i> Add Key/Value Pair
+                                <!-- Button for FORM/POST Parameters (application/x-www-form-urlencoded) -->
+                                <div data-bind="if: $root.formpostkeyvaluepairs() && $root.restPost()"  class="pt-1 d-flex justify-content-end">
+                                    <button id="kvID" data-bind="click: $root.addNotificationMsgKeyValuePair" class="btn btn-success mr-1 mt-1 d-inline-block">
+                                        Add
+                                        <i class="fa fa-fw fa-plus"></i>
                                     </button>
                                 </div>
+                                <!-- Table for RAW BODY: JSON (application/json) -->
+                                <table width="100%" data-bind="visible: !$root.formpostkeyvaluepairs()">
+                                    <thead>
+                                        <tr>
+                                            <th width="100%">Raw Body</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody data-bind="foreach: notificationMessageKeyValues">
+                                        <tr>
+                                            <td>
+                                                <textarea data-bind="textInput:$data.formvalue, onChange" name="formvalue"
+                                                    placeholder="Raw JSON body." class="form-control" type="text"></textarea>
+                                            </td>
+                                        </tr>
+                                    </tbody>
+                                </table>
                             </div>
-                                
+
+                            <!--  AUTHENTICATION  -->
                             <div class="pt-3 form-group">
                                 <label class="pl-1 control-label font-weight-bold">Authorization</label>
                                 <div>
@@ -208,7 +232,6 @@
                                     </select>
                                 </div>
                             </div>
-
                             <div class="p-1 border border-primary form-group" data-bind="visible: authenticationType() == 'BASIC_AUTH'">
                                 <label class="pt-1 control-label font-weight-bold">Username</label>
                                 <div>
@@ -216,13 +239,13 @@
                                         placeholder="userName" class="form-control" type="text" />
                                     <span class="help-block"></span>
                                 </div>
-                                
+
                                 <label data-bind="visible: $root.showPassword()" class="pl-1 control-label font-weight-bold">Password*</label>
-                                
+
                                 <div>
                                     <input id="passwordInput" title="Enter password" data-bind="visible: $root.showPassword() && ($root.mode() == 'edit' || $root.mode() == 'add'),textInput:$data.password" name="password" placeholder="password"
                                         class="form-control" type="password" />
- 
+
 									<div data-bind="visible: !$root.showPassword() && $root.mode() == 'edit'" class="showPasswordButton" >
 									    <button data-bind="click: function(){$root.showPassword(true);}" class="btn btn-warning">
                                             <i class="glyphicon glyphicon-trash"></i>
@@ -230,45 +253,47 @@
                                         </button>
                                     </div>
                                     <span class="help-block"></span>
-                                </div>  
+                                </div>
                             </div>
 
                             <div class="pt-3 form-group">
                                 <label class="pl-1 control-label font-weight-bold">Repeat</label>
-                                <img class="cursor-pointer" id="repeatInfo" alt="Repeat Info" src="assets/images/information.png"
+                                <img class="cursor-pointer" id="repeatInfo" alt="Repeat Info" src="assets/images/information.png" data-toggle="tooltip" data-placement="top"
                                     title="Instructs whether the subscription should be re-triggered for new additions to the aggregated object. If false only first time the conditions are fulfilled
                                     a notification will be triggered. No matter how many times the aggregated object is updated."/>
-                                <div>
-                                    <select id="selectRepeat" data-bind="options: $root.repeat_in,
-                                               optionsText: $data.repeat(),
-                                               value: $data.repeat,
-                                               optionsCaption: 'Choose...'"></select>
-                                    <span class="text-danger font-small" id="repeatNotSet"></span>
-                                    <span class="help-block"></span>
+                                <div data-bind="foreach: $root.repeat_in" >
+                                    <label class="switch">
+                                        <input id="repeatCheckbox" type="checkbox" name="repeatCheck-box" data-bind="
+                                                attr: {value: value}, checked: $parent.repeat, onChange" />
+                                        <span id="repeatCheckboxSpan" class="slider round"></span>
+                                    </label>
+                                    <p class="d-inline" data-bind="text: $parent.repeat() ? 'On' : 'Off'"></p>
                                 </div>
                             </div>
+
+                            <!--  NOTIFICATION META  -->
                             <div class="form-group">
                                 <label class="pl-1 control-label font-weight-bold">NotificationMeta</label>
-                                <img class="cursor-pointer" id="notificationMetaInfo" alt="NotificationMeta Info" src="assets/images/information.png"
+                                <img class="cursor-pointer" id="notificationMetaInfo" alt="NotificationMeta Info" src="assets/images/information.png" data-toggle="tooltip" data-placement="top"
                                     title="The specific point to notify. Example: my@mail.com or host.com/endpoint"/>
                                 <div>
-                                    <span class="text-danger font-small" id="noNotificationMetaGiven"></span>
-                                    <textarea id="metaData" data-bind="textInput:$data.notificationMeta"
+                                    <span class="text-danger font-small" id="invalidNotificationMeta"></span>
+                                    <textarea id="notificationMeta" data-bind="textInput:$data.notificationMeta, onChange"
                                         name="notificationMeta" placeholder="notificationMeta" class="form-control" type="text"></textarea>
                                     <span class="help-block"></span>
                                 </div>
                             </div>
 
-
+                            <!--  REQUIREMENTS  -->
                             <!-- ko foreach:   { data: requirements, as: 'requirements_item' } -->
                             <div class="pl-0 ml-0">
                                 <!-- ko if: $index() !== 0 -->
                                 <h5>OR</h5>
                                 <!-- /ko -->
-                                <img class="cursor-pointer" alt="Requirement Information" src="assets/images/information.png"
+                                <img class="cursor-pointer" alt="Requirement Information" src="assets/images/information.png" data-toggle="tooltip" data-placement="top"
                                     title="Info: 'AND' is used between Conditions in Requirement groups, and 'OR' is used between Requirement groups."/>
                             </div>
-                            <div class="p-1 border border-primary form-group">                            
+                            <div class="p-1 border border-primary form-group">
                                 <label class="control-label font-weight-bold">Requirement</label>
                                 <div id="requirementID">
 
@@ -290,24 +315,27 @@
                                         <div class="pt-1 d-flex justify-content-end">
 
                                             <button data-bind="click: function(data, event) { $root.delete_condition(data, event, requirements_item , $index(), $parentContext.$index() ); }"
-                                                class="btn btn-danger">
-                                                <i class="glyphicon glyphicon-trash"></i>Delete
+                                                class="btn btn-danger mr-1 mt-1 d-inline-block">
+                                                Delete
+                                                <i class="fa fa-fw fa-trash"></i>
                                             </button>
                                         </div>
                                     </div>
                                     <!-- /ko -->
 
                                     <div class="pt-1 d-flex justify-content-end">
-                                        <button id="addCondition" data-bind="click: function(data, event) { $root.add_condition(data, event, $index()); }" class="btn btn-success">
-                                            <i class="glyphicon glyphicon-plus"></i> Add Condition
+                                        <button id="addCondition" data-bind="click: function(data, event) { $root.add_condition(data, event, $index()); }" class="btn btn-success mr-1 mt-1 d-inline-block">
+                                            Add Condition
+                                            <i class="fa fa-fw fa-plus"></i>
                                         </button>
                                     </div>
                                 </div>
                             </div>
                             <!-- /ko -->
 
-                            <button id="addRequirement" data-bind="click: $root.add_requirement" class="btn btn-success float-left">
-                                <i class="glyphicon glyphicon-plus float-right"></i> Add Requirement
+                            <button id="addRequirement" data-bind="click: $root.add_requirement" class="btn btn-success float-left mr-1 mt-1 d-inline-block">
+                                Add Requirement
+                                <i class="fa fa-fw fa-plus"></i>
                             </button>
 
                             <!-- /ko -->
@@ -318,11 +346,13 @@
                 <div class="modal-footer">
                     <span class="text-danger font-medium" id="errorExists"></span>
                     <span class="text-danger font-medium" id="serverError"></span>
-                    <button type="button" id="btnSave" class="btn btn-primary save_record">
+                    <button type="button" id="btnSave" class="btn btn-primary save_record mr-1 mt-1 d-inline-block">
                         Save
+                        <i class="fa fa-fw fa-save"></i>
                     </button>
-                    <button type="button" id="btnFormCancel" class="btn btn-danger" data-dismiss="modal">
+                    <button type="button" id="btnFormCancel" class="btn btn-danger mr-1 mt-1 d-inline-block" data-dismiss="modal">
                         Cancel
+                        <i class="fa fa-fw fa-ban"></i>
                     </button>
                 </div>
             </div>
@@ -338,14 +368,6 @@
         </div>
     </div>
     <!-- End Bootstrap modal -->
-
-
-    <!--
-  <code class="hint mt15">DEBUG INFO</code>
-<div data-bind = "visible: subscription().length > 0" >
-    <p data-bind="text: ko.toJSON(subscription())"></p>
-</div>
--->
 
     <script type="text/javascript" src="js/subscription.js"></script>
     <script type="text/javascript" src="js/downloadFile.js"></script>

--- a/src/main/resources/templates/switch-backend.html
+++ b/src/main/resources/templates/switch-backend.html
@@ -34,7 +34,8 @@
                     <td data-bind="text: port"></td>
                     <td data-bind="text: path"></td>
                     <td class="text-center"><input type="checkbox" disabled="disabled" data-bind="checked: https"/></td>
-                    <td class="text-center"><a href="#" data-bind="click: $parent.removeInstance, attr: { id: 'removeBtn' + $index()}">Remove</a></td>
+                    <td class="text-center"><a href="#" data-bind="click: $parent.removeInstance, attr: { id: 'removeBtn' + $index()},
+                                                    style:{visibility:($index() === 0) ? 'hidden' : 'visible'}">Remove</a></td>
                 </tr>
                 </tbody>
             </table>

--- a/src/main/resources/templates/testRules.html
+++ b/src/main/resources/templates/testRules.html
@@ -20,8 +20,8 @@
             <div class="p-1 col-lg-6 col-md-6 col-12 border border-right border-success" id="testRulesDOMObject">
                 <div class="d-flex flex-wrap">
 	                <div class="col-11">
-	                   <button class="btn btn-primary upload_rules rule-button mr-1 mt-1 d-inline-block">
-                           Upload Rules
+	                   <button class="btn btn-primary upload_rules mr-1 mt-1 d-inline-block">
+                           Load Rules from file
                            <i class="fa fa-fw  fa-upload"></i>
                        </button>
                        <input class="hide" type='file' id='uploadRulesFile' name='file'/>
@@ -65,8 +65,8 @@
             <div class="p-1 col-lg-6 col-md-6 col-12 border border-right border-success" id="testEventsDOMObject">
                 <div class="d-flex flex-wrap">
                     <div class="col-11">
-                       <button class="btn btn-primary upload_events rule-button mr-1 mt-1 d-inline-block">
-                           Upload Events
+                       <button class="btn btn-primary upload_events mr-1 mt-1 d-inline-block">
+                           Load Events from file
                            <i class="fa fa-fw  fa-upload"></i>
                        </button>
                        <input class="hide" type='file' id='uploadEventsFile' name='file'/>
@@ -128,6 +128,19 @@
             </div>
         </div>
     </div>
+    <div id="AppendReplaceModal" class="modal fade" role="dialog">
+	  <div class="modal-dialog" role="document">
+	    <div class="modal-content">
+	      <div class="modal-header justify-content-center">
+	        <h5 class="modal-title">Do you want to replace or append?</h5>
+	      </div>
+	      <div class="modal-footer justify-content-center">
+            <button id="replaceButton" type="button" class="btn btn-primary">Replace</button>
+            <button id="appendButton" type="button" class="btn btn-info">Append</button>
+	      </div>
+	    </div>
+	  </div>
+	</div>
     <div id="aggregatedObjectModal" class="modal fade" role="dialog">
 	  <div class="modal-dialog modal-width-aggregated" role="document">
 	    <div class="modal-content">

--- a/src/main/resources/templates/testRules.html
+++ b/src/main/resources/templates/testRules.html
@@ -33,6 +33,10 @@
                            Add Rule
                            <i class="fa fa-fw  fa-plus"></i>
                        </button>
+                       <button class="btn btn-danger clear_all_rules rule-button mr-1 mt-1 d-inline-block" data-bind="click : $root.clearAllRules.bind()">
+                           Clear All Rules
+                           <i class="fa fa-fw  fa-trash"></i>
+                       </button>
 	                </div>
                     <div>
 	                    <img class="cursor-pointer" id="uploadRulesInfo" alt="Upload Information" src="assets/images/information.png" data-toggle="tooltip" data-placement="top" title="Upload rules must be in a json list, Ex: [{},{}]"/>
@@ -73,6 +77,10 @@
                        <button class="btn btn-primary add_event rule-button mr-1 mt-1 d-inline-block" data-bind="click : $root.addEvent.bind($data, {})">
                            Add Event
                            <i class="fa fa-fw  fa-plus"></i>
+                       </button>
+                       <button class="btn btn-danger clear_all_events rule-button mr-1 mt-1 d-inline-block" data-bind="click : $root.clearAllEvents.bind()">
+                           Clear All Events
+                           <i class="fa fa-fw  fa-trash"></i>
                        </button>
                     </div>
                     <div>

--- a/src/test/java/com/ericsson/ei/frontend/BackendInformationControllerUtilsTest.java
+++ b/src/test/java/com/ericsson/ei/frontend/BackendInformationControllerUtilsTest.java
@@ -143,14 +143,6 @@ public class BackendInformationControllerUtilsTest {
                 "{\"message\": \"Backend instance with name 'TestName' was selected.\"}".toString(), HttpStatus.OK);
         response = backendInfoContrUtils.handleRequestToSwitchBackEnd(mockedRequest);
         assertEquals(expectedResponse, response);
-
-        // Test with input as json.
-        when(stream.collect(any())).thenReturn(instancesWithActive.toString());
-        expectedResponse = createExpectedResponse(
-                "{\"message\": \"Backend instance with name 'otherName' was selected.\"}".toString(), HttpStatus.OK);
-        response = backendInfoContrUtils.handleRequestToSwitchBackEnd(mockedRequest);
-        assertEquals(expectedResponse, response);
-
     }
 
     @Test

--- a/wiki/Add-Subscription.md
+++ b/wiki/Add-Subscription.md
@@ -1,0 +1,21 @@
+# Add Subscription
+
+This form is used to add subscription through frontend GUI. Here is a description of the elements available on this form.
+
+**Load Subscription Template:** In this dropdown list options are given to select a specific template for the subscription form. Currently, the following options are listed: Jenkins Pipeline Parametrized Job Trigger, REST POST and Mail Trigger.
+
+**SubscriptionName:** A field to give a name to the current subscription. Only letters, underscore and numbers are allowed in this field.
+
+**NotificationType:** A dropdown list with two options, i.e., REST POST and Mail Trigger, depending on how a subscriber want to be notified when a subscription is fulfilled.
+
+**RestPostMediaType:** A dropdown list that provides options for selecting a specific form content type. The options available in the list depends on the selected template type.
+
+**NotificationMessage:** It is used to send a message to a specific client. The format of the message depends on the options selected in the NotificationMessage and RestPostMediaType. A button, “Add Key/Value pair”, in this field may be used to add more messages.
+
+**Authorization:** A list to select authorization type. Currently, only one authorization type is provided which is “BASIC_AUTH”. The option “NO_AUTH” implies that authorization is not required.
+
+**Repeat:** A drop down list to choose either true or false. It depends whether same subscription should be re-triggered for new additions to the aggregated object. If false, the notification will be triggered only the first time when conditions are fulfilled. 
+
+**NotificationMeta:** A unique address need to be added for notification.
+
+**Requirement:** It is used to add a requirement, which need to be fulfilled before a subscription is triggered. Requirement is added in the form of a condition (with a specific format). More than one conditions may be added under one requirement by using “Add Condition” button. It should be noted that conditions under one requirement are connected by logical “AND”. Thus all conditions udder one requirement need to be satisfied before a subscription is triggered. More than one requirements may be added by “Add Requirement” button. Requirements are connected by logical “OR”.

--- a/wiki/GUI-Overview.md
+++ b/wiki/GUI-Overview.md
@@ -1,0 +1,9 @@
+# GUI Overview
+
+Eiffel Intelligence Frontend GUI can be divided into two parts a navigation window and a work window.
+<img src="https://github.com/eiffel-community/eiffel-intelligence-frontend/blob/master/src/main/resources/static/assets/images/GUI_subscription_example.png">
+</img>
+
+As the name suggests, navigation window provides its users one click access to the resources to interact with EI. This window contains some buttons. Clicking on any of these buttons result in either opening an interactive form in the work window or opening a new window with some information resource.
+
+A detailed description of the interactive elements present in the navigation window and corresponding interactions in the work window is described in the following pages.

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -1,0 +1,4 @@
+Eiffel Intelligence Frontend provides Eiffel Intelligence (EI) users a simple and easy to use GUI. More precisely, Eiffel Intelligence Frontend allows the configuration of subscription and aggregation rules in Eiffel Intelligence through a graphical interface.
+
+EI has two components, namely Eiffel Intelligence (Backend) and Eiffel Intelligence Frontend. In Eiffel GitHub these two components are represented by two different repositories. Eiffel Intelligence (Backend) implements core functionalities of EI and Eiffel Intelligence Frontend take care of the user interactions through an interface.
+

--- a/wiki/Subscription-Handling.md
+++ b/wiki/Subscription-Handling.md
@@ -1,0 +1,20 @@
+# Subscription Handling
+
+Clicking on the Subscription Handling element will display some buttons in main page which help perform a number of subscription related actions. A table may become visible, which is populated by the information about the stored (if any) subscriptions in the connected database. This view is also the default view of the Eiffel Intelligence Frontend, once the authentication (if enabled)is done .
+
+#### _Add Subscription_ 
+This button opens a form with a number of fields to create a subscription through subscription endpoint (POST /subscriptions). 
+#### _Reload_ 
+This button reloads the data from the database and refresh the data in the subscription table
+#### _Bulk Delete_
+This button deletes all the selected subscriptions in the table from the database.
+#### _Get Template_
+This button downloads a subscription template
+#### _Upload Subscriptions_
+This button help uploads a subscription by opening a file explorer
+#### _EI Backend Status_
+This button indicates, through its colour, whether a backend instance is connected with frontend or not. The green colour means backend is connected while red means no instance is connected.
+#### _Search_
+To search subscriptions with matching names in the database (displayed in the table).
+
+**_More Subscriptions related information can be found [here](https://github.com/eiffel-community/eiffel-intelligence/tree/master/wiki/Subscription-API.md) and [here](https://github.com/eiffel-community/eiffel-intelligence/tree/master/wiki/Subscriptions.md)_**

--- a/wiki/Test-Rules.md
+++ b/wiki/Test-Rules.md
@@ -1,0 +1,657 @@
+# Test Rules
+
+Clicking on the Test Rule element in the navigator window opens an interface in the work window and interacts with the /rules/rule-check end point of Eiffel Intelligence. This interface can be used to test rules on events.
+
+<h3>Rule testing mechanism via "Test Rules" GUI interface</h3>
+<p>The graphical user interface for testing rules consists of two panes. Left pane is intended to load the rule. To
+    do this one will need to chose
+    the rule type from dropdown menu, then insert the rule content and upload the rule. Right pane is intended for
+    uploading the Eiffel events.
+    After uploading the events one may check the result of applying rules by pressing "Find Aggregated Object" button
+    specifying the UUID of
+    this object.
+</p>
+<img src="https://github.com/eiffel-community/eiffel-intelligence-frontend/blob/master/src/main/resources/static/assets/images/GUI_frontend_example.png">
+</img>
+<h3>Introduction</h3>
+<p>JMESPath is a query language for JSON. You can extract and transform elements from a JSON document.
+    The result of applying a JMESPath expression against a JSON document will always result in valid JSON,
+    provided there are no errors during the evaluation process.
+    This also means that, with the exception of JMESPath expression types, JMESPath only supports the same types
+    support by JSON:</p>
+<ul>
+    <li>number (integers and double-precision floating-point format in JSON)</li>
+    <li>string</li>
+    <li>boolean (true or false)</li>
+    <li>array (an ordered, sequence of values)</li>
+    <li>object (an unordered collection of key value pairs)</li>
+    <li>null</li>
+</ul>
+<p>Let's go to an example of simple query called identifier. An identifier is the most basic expression and can be used
+    to extract a
+    single element from a JSON object. The return value for an identifier is the value associated with the identifier.
+    If the identifier does not exist in the JSON document, then a null value is returned.
+    Assume that we have such JSON object <code>{"a": {"b": {"c": {"d": "value"}}}}</code> and we need to get the string
+    <code>"value"</code> from object. The JMESPath identifier will be <code>a.b.c.d</code>.
+    <a href="http://jmespath.org/specification.html#identifiers">JMESPath identifier documentation</a>.</p>
+<p>Lets do some more complicated example on Eiffel event
+    where we need to extract the <code>"SUCCESS"</code> from the event. The identifier for such JSON query will be
+    <code>data.value</code></p>
+
+<h3>Aggregated object</h3>
+<p>The term "Aggregated object" in Eiffel syntax means a composition of several Eiffel events into one big JSON object
+    using a special
+    rule mechanism. The main purpose for aggregating objects is to create customizable JSON documents which could later
+    be used for
+    visualization and better tracing using different visual engines (VE).
+    Inside the rule mechanism the JMESPath is used for selecting the needed data from Eiffel event and inserting it.</p>
+<h3>Rule set up</h3>
+<p>The rules for object aggregation consist of a JSON object with a defined structure inside it. The key in this object
+    is a rule specification and
+    the value is a JMESPath identifier. A separate rule is created for each event type that is going to take part in
+    the creation of the aggregated
+    object. This means that if you want to create your aggregated object from 3 event types and then all other event
+    types are ignored. Each rule might contain some of the keys listed below:</p>
+<ul>
+    <li><code>"TemplateName"</code> - used for specifying a template group, any string you like to name your template</li>
+    <li><code>"Type"</code> - Eiffel event <a href="https://github.com/Ericsson/eiffel/tree/master/eiffel-vocabulary">type</a>,
+        which will be used to find the matching template while creating the aggregated object.
+        Example: <code>"EiffelConfidenceLevelModifiedEvent"</code>
+    </li>
+    <li><code>"TypeRule"</code> - JMESPath identifier for the location of Eiffel event type in the received Eiffel
+        event. Example: <code>"meta.type"</code>.
+    </li>
+    <li><code>"IdRule"</code> - JMESPath identifier for the location of Eiffel event id in received Eiffel event.
+        Example: <code>"meta.id"</code>.
+    </li>
+    <li><code>"StartEvent"</code> - Denotes to start the object aggregation. If StartEvent is <code>"YES"</code> then
+        it will be the first processed event in the aggregation sequence. If StartEvent is <code>"NO"</code> then the
+        Eiffel event is part of a sequence and will be stored until the sequence has started.
+    </li>
+    <li><code>"MatchIdRules"</code> - Denotes the received event id of the object. Example: <code>"%IdentifyRules_objid%"</code></li>
+    <li><code>"IdentifyRules"</code> - JMESPath identifier of the event id that will be used in the aggregated object.
+        Should produce an JSON array,
+        for example <code>"[meta.id]"</code> which will return the specified field in an array
+        <code>["sb6e51h0-25ch-4dh7-b9sd-876g8e6kde47"]</code>.
+        Another common example is
+        <code>"links | [?type=='CAUSE'].target"</code> which will extract the event id from the <code>links</code>
+        array value of
+        <code>target</code>, where "type" is equal to "CAUSE".
+        Link looks like <code>{"links": [
+                {
+                "target": "f37d59a3-069e-4f4c-8cc5-a52e73501a75",
+                "type": "CAUSE"
+                },
+                {
+                "target": "cfce572b-c3j4-441e-abc9-b62f48080ca2",
+                "type": "ELEMENT"
+                }
+                ] }</code>
+    </li>
+    <li><code>"ExtractionRules"</code> - JSON object of JMESPath identifier(s) which will create or modify the existing
+        data in the aggregated object.
+        For example <code>"{confidenceLevels :[{ eventId:meta.id, time:meta.time, name:data.name, value:data.value}]}"</code>
+        will create
+        JSON object "confidenceLevels" and the value of it will be an array with 1 JSON element. This JSON object key
+        will
+        be "eventId" and the value
+        will be the result of searching for "meta.id" identifier in the received Eiffel event,
+        for example <code>"cfce572b-c3j4-441e-abc9-b62f48080ca2"</code> and so on.
+        The result of the above specified extraction rules could look something like the following JSON object
+        <code>{"confidenceLevels":[{"eventId":"f37d59a3-069e-4f4c-8cc5-a52e73501a75",
+                "name":"readyForDelivery","time":1481875944272,"value":"SUCCESS"}]}</code> which could be added to the
+        root of the aggregated object or
+        to the inner structure of the aggregated object depending on MergeResolverRules.
+    </li>
+    <li><code>"MergeResolverRules"</code> - JMESPath identifier of the place to insert the JSON object from
+        "ExtractionRules".
+        If MergeResolverRules is <code>null</code> ExtractionRules object will be inserted to the root of the
+        aggregated
+        object.
+        An example is <code>"[{NONEPATH:NONE}, {test_suite: [{ test_case : [{ trigger_event_id:meta.id}]} ]} ]"</code>
+        which consists of an
+        array with two fields, first is the expression <code>{NONEPATH:NONE}</code> that <strong>should not exist</strong>
+        in the aggregated object,
+        it could be any words you like.
+        Second part is <code>{test_suite: [{ test_case : [{ trigger_event_id:meta.id}]}</code> that will form a new
+        JSON object that will be
+        inserted to the aggregated object after evaluation of "meta.id".
+        Another example could be inserting the object obtained in "ExtractionRules" to the array element that has <code>trigger_event_id</code>
+        matching the event id target field from incoming event "TEST_CASE_EXECUTION" link JSON object.
+    </li>
+    <li><code>"HistoryIdentifyRules"</code> - JMESPath identifier of event id that will be used in the aggregated
+        object
+        for internal composition. Follows the same instructions as "IdentifyRules".
+    </li>
+    <li><code>"HistoryExtractionRules"</code> - JSON object of JMESPath identifier(s) which will create or modify the
+        existing data in the aggregated
+        object for internal composition. Follows the same instructions as "ExtractionRules".
+    </li>
+    <li><code>"HistoryPathRules"</code> - JMESPath identifier of the place where to insert the JSON object form
+        "ExtractionRules" in the aggregated
+        object for internal composition. Follows the same instructions as "MergeResolverRules".
+    </li>
+    <li><code>"DownstreamIdentifyRules"</code> - JMESPath identifier of event id that will be used in the aggregated
+        object
+        for external composition. Follows the same instructions as "IdentifyRules".
+    </li>
+    <li><code>"DownstreamExtractionRules"</code> - JSON object of JMESPath identifier(s) which will create or modify
+        the existing data in
+        the aggregated object for external composition. Follows the same instructions as "ExtractionRules".
+    </li>
+    <li><code>"DownstreamMergeRules"</code> - JMESPath identifier of the place where to insert the JSON object form
+        "ExtractionRules" in
+        the aggregated object for external composition. Follows the same instructions as "MergeResolverRules".
+    </li>
+    <li><code>"ProcessRules"</code> - Allows modifying of the aggregated object obtained after processing of previously
+        mentioned rules.
+        This rule will be executed in the end, right before storing the aggregated object to database, only has access
+        to the aggregated object.
+    </li>
+    <li><code>"ProcessFunction"</code> - Reserved for future use.</li>
+</ul>
+
+
+<h3>The most common operation you would do</h3>
+<h4>Creating new aggregated object from an Eiffel event</h4>
+<p>Lets consider that an aggregated object should be created upon receiving the EiffelArtifactCreated event, and it
+    should
+    form the aggregated object
+    from the received event. The aggregated object should contain the keys "id", "artifactId", and "temp", where "id"
+    will be
+    extracted from the received
+    event key "id", artifactId will be extracted from the event GAV and temp will be set to true.</p>
+<details>
+    <summary>EiffelArtifactCreatedEvent example, click to unfold</summary>
+    <pre>
+{
+   "meta":{
+      "id":"66208918-4422-42cb-a0bf-17b15d1043d2",
+      "type":"EiffelArtifactCreatedEvent",
+      "version":"1.1.0",
+      "time":1522326376538,
+      "tags":[
+
+      ],
+      "source":{
+         "domainId":"eiffel.aaa.bbb",
+         "host":"eselivm2v1464l",
+         "name":"fem-eiffel",
+         "serializer":{
+            "groupId":"com.github.Ericsson",
+            "artifactId":"eiffel-remrem-semantics",
+            "version":"0.0.10"
+         },
+         "uri":"https://some.url.com:8443/jenkins/job/user_test/31/"
+      }
+   },
+   "data":{
+      "gav":{
+         "groupId":"com.ericsson.test",
+         "artifactId":"test_arm_test",
+         "version":"0.0.31"
+      },
+      "fileInformation":[
+         {
+            "classifier":"",
+            "extension":"txt"
+         }
+      ],
+      "buildCommand":"",
+      "requiresImplementation":"NONE",
+      "dependsOn":[
+
+      ],
+      "implements":[
+
+      ],
+      "name":"",
+      "customData":[
+
+      ]
+   },
+   "links":[
+
+   ]
+}</pre>
+</details>
+<p>So we need to form a set of basic rules for the Eiffel event that will fulfill our aggregated object.
+    Keep in mind that we are adding to the root of aggregated object so no need to specify MergeResolverRules.</p>
+<pre>
+{
+   "TemplateName":"ARTIFACT_1",
+   "Type":"EiffelArtifactCreatedEvent",
+   "TypeRule":"meta.type",
+   "IdRule":"meta.id",
+   "StartEvent":"YES",
+   "IdentifyRules":"[meta.id]",
+   "MatchIdRules":{
+      "_id":"%IdentifyRules_objid%"
+   },
+   "ExtractionRules":"{ id : meta.id, artifactId : data.gav.artifactId, temp : `\"true\"` }"
+}
+</pre>
+And here is the resulting aggregated object.
+<pre>
+{
+   "_id":"b46ef12d-25gb-4d7y-b9fd-8763re66de47",
+   "aggregatedObject":{
+      "id":"b46ef12d-25gb-4d7y-b9fd-8763re66de47",
+      "artifactId": "test_arm_test",
+      "temp":"true",
+      "TemplateName":"ARTIFACT_1"
+   }
+}</pre>
+
+<h4>Inserting a JSON array to the aggregated object</h4>
+<p>Lets consider that upon receiving an EiffelConfidenceLevelModifiedEvent message, confidence levels array should be
+    inserted to the aggregated
+    object. Each time such an eiffel message is received it should form a new element and be inserted into aggregated
+    object.
+    Rule example is below.</p>
+<pre>
+{
+   "TemplateName":"ARTIFACT_1",
+   "Type":"EiffelConfidenceLevelModifiedEvent",
+   "TypeRule":"meta.type",
+   "IdRule":"meta.id",
+   "StartEvent":"NO",
+   "IdentifyRules":"links | [?type=='SUBJECT'].target",
+   "MatchIdRules":{
+      "_id":"%IdentifyRules_objid%"
+   },
+   "ExtractionRules":"{ eventId:meta.id, time:meta.time, name:data.name, value:data.value }",
+   "MergeResolverRules":"[ {NONEPATH:NONE}, {confidenceLevels: [{ eventId: meta.id }]} ]"
+}</pre>
+<p>When receiving an EiffelConfidenceLevelModifiedEvent message the aggregated object <code>"id"</code> is located in
+    the <code>links</code>
+    object where the
+    array is located. Each element of the array is a valid JSON object. There are key-value pairs in this array, and in
+    one
+    of those there should be a key called
+    <code>"type"</code> with the value
+    <code>"SUBJECT"</code> and we need to extract the value of <code>"target"</code> which will be our id for
+    the aggregated object.
+    The identifier described is placed in <code>"IdentifyRules":"links | [?type=='SUBJECT'].target"</code>.
+    At this point we know the needed aggregated object id and now we need to specify the desired location for the
+    confidence level information.
+    Lets move the data obtained in "ExtractionRules" under the <code>"confidenceLevels"</code> key in the root of
+    the aggregated object and the value
+    should be an array. The identifier is expressed as <code>{confidenceLevels: [{ eventId: meta.id }]}</code>.
+    To insert the
+    new element to an array we need to provide an expression that won't be found in the existing aggregated object (if
+    the provided identifier is found in the aggregated object, it will modify the existing element). In our case <code>{NONEPATH:NONE}</code>
+    does
+    not exist in the aggregated
+    object so we can use that. The full expression would then be
+    <code>"MergeResolverRules":"[ {NONEPATH:NONE}, {confidenceLevels: [{ eventId: meta.id }]} ]"</code>.
+</p>
+
+
+<details>
+    <summary>EiffelConfidenceLevelModifiedEvent for example, click to unfold</summary>
+    <pre>
+{
+   "links":[
+      {
+         "target":"40df7fc4-0c40-40a3-a349-9f6da0ba81c5",
+         "type":"CAUSE"
+      },
+      {
+         "target":"6acc3c87-75e0-4b6d-88f5-b1a5d4e62b43",
+         "type":"SUBJECT"
+      }
+   ],
+   "meta":{
+      "id":"f37d59a3-069e-4f4c-8cc5-a52e73501a76",
+      "source":{
+         "domainId":"example.domain"
+      },
+      "time":1481875988767,
+      "type":"EiffelConfidenceLevelModifiedEvent",
+      "version":"1.0.0"
+   },
+   "data":{
+      "value":"SUCCESS",
+      "customData":[
+         {
+            "value":"CLM2",
+            "key":"name"
+         },
+         {
+            "value":1,
+            "key":"iteration"
+         }
+      ],
+      "name":"performance"
+   }
+}</pre>
+</details>
+
+<details>
+    <summary>Aggregated object before receiving EiffelConfidenceLevelModifiedEvent click to unfold</summary>
+    <pre>
+{
+   "_id":"6acc3c87-75e0-4b6d-88f5-b1a5d4e62b43",
+   "aggregatedObject":{
+      "id":"6acc3c87-75e0-4b6d-88f5-b1a5d4e62b43",
+      "type":"EiffelArtifactCreatedEvent",
+      "time":1481875891763,
+      "gav":{
+         "artifactId":"sub-system",
+         "version":"1.1.0",
+         "groupId":"com.mycompany.myproduct"
+      },
+      "fileInformation":[
+         {
+            "classifier":"debug",
+            "extension":"jar"
+         },
+         {
+            "classifier":"test",
+            "extension":"txt"
+         },
+         {
+            "classifier":"application",
+            "extension":"exe"
+         }
+      ],
+      "buildCommand":null,
+      "TemplateName":"ARTIFACT_1"
+   }
+}
+</pre>
+</details>
+
+<details>
+    <summary>Aggregated object after receiving EiffelConfidenceLevelModifiedEvent click to unfold</summary>
+    <pre>
+{
+   "_id":"6acc3c87-75e0-4b6d-88f5-b1a5d4e62b43",
+   "aggregatedObject":{
+      "fileInformation":[
+         {
+            "extension":"jar",
+            "classifier":"debug"
+         },
+         {
+            "extension":"txt",
+            "classifier":"test"
+         },
+         {
+            "extension":"exe",
+            "classifier":"application"
+         }
+      ],
+      "buildCommand":null,
+      "confidenceLevels":[
+         {
+            "eventId":"f37d59a3-069e-4f4c-8cc5-a52e73501a76",
+            "name":"performance",
+            "time":1481875988767,
+            "value":"SUCCESS"
+         }
+      ],
+      "TemplateName":"ARTIFACT_1",
+      "id":"6acc3c87-75e0-4b6d-88f5-b1a5d4e62b43",
+      "time":1481875891763,
+      "type":"EiffelArtifactCreatedEvent",
+      "gav":{
+         "groupId":"com.mycompany.myproduct",
+         "artifactId":"sub-system",
+         "version":"1.1.0"
+      }
+   }
+}
+</pre>
+</details>
+
+
+<h4>Updating an array in JSON objects where the a field is pointing to Eiffel message id</h4>
+
+<p>Lets consider that upon receiving an EiffelTestCaseStartedEvent message we need to update the aggregated object. The event message has a key <code>"TEST_CASE_EXECUTION"</code> that contains an id that
+    matches the one stated in the aggregated object and the data in that JSON object needs to be updated. As a result of applying the
+    rule,
+    the key <code>ongoing</code> in the aggregated
+    object will change the value from <code>"ongoing":"false"</code>
+    to <code>"ongoing":"true"</code>.</p>
+
+<details>
+    <summary>Rules for EiffelTestCaseStartedEvent</summary>
+    <pre>
+{
+   "TemplateName":"TEST_EXECUTION_1",
+   "Type":"EiffelTestCaseStartedEvent",
+   "TypeRule":"meta.type",
+   "IdRule":"meta.id",
+   "StartEvent":"NO",
+   "IdentifyRules":"links | [?type=='TEST_CASE_EXECUTION'].target",
+   "MatchIdRules":{
+      "_id":"%IdentifyRules_objid%"
+   },
+   "ExtractionRules":"{ ongoing : `\"true\"`}",
+   "MergeResolverRules":"[{NONEPATH:NONE}, {test_suite: [{ test_case : [{ trigger_event_id: links | [?type=='TEST_CASE_EXECUTION'] | [0].target }]} ]}]",
+   "ArrayMergeOptions":"",
+   "HistoryIdentifyRules":"",
+   "HistoryExtractionRules":"",
+   "ProcessRules":null,
+   "ProcessFunction":null
+}</pre>
+</details>
+<details>
+    <summary>Aggregated object before receiving EiffelTestCaseStartedEvent, click to unfold</summary>
+    <pre>
+{
+   "_id":"b46ef12d-25gb-4d7y-b9fd-8763re66de47",
+   "aggregatedObject":{
+      "ongoing":"true",
+      "test_suite":[
+         {
+            "test_case":[
+               {
+                  "ongoing":"false",
+                  "test_data":null,
+                  "trigger_event_id":"v46ef19d-20gb-4d2y-h9fa-87dada6kde47"
+               }
+            ]
+         }
+      ],
+      "TemplateName":"TEST_EXECUTION_1",
+      "id":"b46ef12d-25gb-4d7y-b9fd-8763re66de47",
+      "time":1234567890,
+      "type":"EiffelActivityTriggeredEvent",
+      "version":"1.0.0",
+      "test_suite_name":"Pre-release installation and security verification"
+   }
+}</pre>
+</details>
+
+<details>
+    <summary>EiffelTestCaseStartedEvent, click to unfold</summary>
+    <pre>
+{
+   "meta":{
+      "type":"EiffelTestCaseStartedEvent",
+      "version":"1.0.0",
+      "time":1234567890,
+      "id":"v46ef19d-20ab-4d2y-h9fe-87haha6kde47"
+   },
+   "data":{
+      "executor":"My Test Framework",
+      "liveLogs":[
+         {
+            "name":"My test log",
+            "uri":"file:///tmp/logs/data.log"
+         }
+      ]
+   },
+   "links":[
+      {
+         "type":"ENVIRONMENT",
+         "target":"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeee1"
+      },
+      {
+         "type":"TEST_CASE_EXECUTION",
+         "target":"v46ef19d-20gb-4d2y-h9fa-87dada6kde47"
+      }
+   ]
+}</pre>
+</details>
+
+<details>
+    <summary>Aggregated object after receiving EiffelTestCaseStartedEvent, click to unfold</summary>
+    <pre>
+{
+   "_id":"b46ef12d-25gb-4d7y-b9fd-8763re66de47",
+   "aggregatedObject":{
+      "ongoing":"true",
+      "test_suite":[
+         {
+            "test_case":[
+               {
+                  "ongoing":"true",
+                  "test_data":null,
+                  "trigger_event_id":"v46ef19d-20gb-4d2y-h9fa-87dada6kde47"
+               }
+            ]
+         }
+      ],
+      "TemplateName":"TEST_EXECUTION_1",
+      "id":"b46ef12d-25gb-4d7y-b9fd-8763re66de47",
+      "time":1234567890,
+      "type":"EiffelActivityTriggeredEvent",
+      "version":"1.0.0",
+      "test_suite_name":"Pre-release installation and security verification"
+   }
+}</pre>
+</details>
+
+
+<h4>Upstream events</h4>
+<p>Upstream events in Eiffel means those events that were processed/issued before or
+    were the cause to
+    the specified event. Such a connection works via the
+    <a href="https://github.com/Ericsson/eiffel/blob/master/eiffel-syntax-and-usage/the-links-object.md">links</a>
+    mechanism. For example we have
+    EiffelSourceChangeCreatedEvent,
+    EiffelSourceChangeSubmittedEvent, EiffelArtifactCreatedEvent, EiffelArtifactPublishedEvent, so the upstream events
+    for
+    EiffelArtifactCreatedEvent will be EiffelSourceChangeCreatedEvent andEiffelSourceChangeSubmittedEvent.
+</p>
+
+
+<h4>Downstream events</h4>
+<p>Downstream events in Eiffel means those events that will be issued after or were the
+    outcome to
+    the specified event. Such a connection works via the
+    <a href="https://github.com/Ericsson/eiffel/blob/master/eiffel-syntax-and-usage/the-links-object.md">links</a>
+    mechanism. For example we have
+    EiffelSourceChangeCreatedEvent,
+    EiffelSourceChangeSubmittedEvent, EiffelArtifactCreatedEvent, EiffelArtifactPublishedEvent, so the downstream event
+    for
+    EiffelArtifactCreatedEvent will be EiffelArtifactPublishedEvent.
+</p>
+
+
+<h4>Rule examples with different identifiers that might be used as a reference</h4>
+<pre>
+{
+   "TemplateName":"TEST_EXECUTION_1",a
+   "Type":"EiffelTestCaseTriggeredEvent",
+   "TypeRule":"meta.type",
+   "IdRule":"meta.id",
+   "StartEvent":"NO",
+   "IdentifyRules":"links | [?type=='CONTEXT'].target",
+   "MatchIdRules":{
+      "_id":"%IdentifyRules_objid%"
+   },
+   "ExtractionRules":"{trigger_event_id : meta.id, test_data : data.testcase, ongoing : `\"false\"`}",
+   "MergeResolverRules":"[{NONEPATH:NONE},  {test_suite: [{ test_case : [{ trigger_event_id:meta.id}]} ]}]",
+   "ArrayMergeOptions":"",
+   "HistoryIdentifyRules":"",
+   "HistoryExtractionRules":"",
+   "ProcessRules":null,
+   "ProcessFunction":null
+}
+{
+   "TemplateName":"TEST_EXECUTION_1",
+   "Type":"EiffelActivityFinishedEvent",
+   "TypeRule":"meta.type",
+   "IdRule":"meta.id",
+   "StartEvent":"NO",
+   "IdentifyRules":"links | [?type=='ACTIVITY_EXECUTION'].target",
+   "MatchIdRules":{
+      "_id":"%IdentifyRules_objid%"
+   },
+   "ExtractionRules":"{ ongoing : `\"false\"`, outcome : data.outcome}",
+   "MergeResolverRules":null,
+   "ArrayMergeOptions":"",
+   "HistoryIdentifyRules":"",
+   "HistoryExtractionRules":"",
+   "ProcessRules":null,
+   "ProcessFunction":null
+}
+{
+   "TemplateName":"ARTIFACT_1",
+   "Type":"EiffelConfidenceLevelModifiedEvent",
+   "TypeRule":"meta.type",
+   "IdRule":"meta.id",
+   "StartEvent":"NO",
+   "IdentifyRules":"links | [?type=='SUBJECT'].target",
+   "MatchIdRules":{
+      "_id":"%IdentifyRules_objid%"
+   },
+   "ExtractionRules":"{confidenceLevels :[{ eventId:meta.id, time:meta.time, name:data.name, value:data.value}]}",
+   "ArrayMergeOptions":"",
+   "HistoryIdentifyRules":"",
+   "HistoryExtractionRules":"",
+   "ProcessRules":null,
+   "ProcessFunction":null
+}
+{
+   "TemplateName":"ARTIFACT_1",
+   "Type":"EiffelArtifactCreatedEvent",
+   "TypeRule":"meta.type",
+   "IdRule":"meta.id",
+   "StartEvent":"YES",
+   "IdentifyRules":"[meta.id]",
+   "MatchIdRules":{
+      "_id":"%IdentifyRules_objid%"
+   },
+   "ExtractionRules":"{ id : meta.id, type : meta.type, time : meta.time, gav : data.gav, fileInformation : data.fileInformation, buildCommand : data.buildCommand }",
+   "DownstreamIdentifyRules":"links | [?type=='COMPOSITION'].target",
+   "DownstreamMergeRules":"{\"externalComposition\":{\"eventId\":%IdentifyRules%}}",
+   "DownstreamExtractionRules":"{artifacts: [{id : meta.id}]}",
+   "ArrayMergeOptions":"",
+   "HistoryIdentifyRules":"links | [?type=='COMPOSITION'].target",
+   "HistoryExtractionRules":"{internalComposition:{artifacts: [{id : meta.id}]}}",
+   "HistoryPathRules":"{artifacts: {id: meta.id}}",
+   "ProcessRules":null,
+   "ProcessFunction":null
+}
+{
+   "TemplateName":"ARTIFACT_1",
+   "Type":"EiffelTestCaseFinishedEvent",
+   "TypeRule":"meta.type",
+   "IdRule":"meta.id",
+   "StartEvent":"NO",
+   "IdentifyRules":"links | [?type=='TEST_CASE_EXECUTION'].target",
+   "MatchIdRules":{
+      "$and":[
+         {
+            "aggregatedObject.testCaseExecutions.testCaseStartedEventId":"%IdentifyRules%"
+         }
+      ]
+   },
+   "ExtractionRules":"{ testCaseFinishEventId:meta.id, testCaseFinishedTime:meta.time, testCase:data.outcome}",
+   "MergeResolverRules":"{\"testCaseStartedEventId\":%IdentifyRules%}",
+   "ArrayMergeOptions":"",
+   "HistoryIdentifyRules":"",
+   "HistoryExtractionRules":"",
+   "ProcessRules":"{testCaseDuration : diff(testCaseExecutions[0].testCaseFinishedTime, testCaseExecutions[0].testCaseStartedTime)}",
+   "ProcessFunction":"difference"
+}
+</pre>
+
+<p>Also note that if you refer to a key that does not exist, a value of null (or the language equivalent of null) is
+    returned.</p>


### PR DESCRIPTION
### Applicable Issues
The default back end cannot be removed from the web gui. But the "Remove" button is still present for the default back end in the switch back end page. This may be confusing and the button should be removed in case the back end is marked as defaultBackend. 

### Description of the Change
Because default instance is allways first in the list, remove button for the first element is hide.

### Alternate Designs


### Benefits
It is not confusing anymore

### Possible Drawbacks
It will not work if default instance change position in the list.

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Jakub Binieda, jakub.binieda@ericsson.com
