### PR TITLE
Add button to download events

### DIFF
--- a/src/main/resources/static/js/testrules.js
+++ b/src/main/resources/static/js/testrules.js
@@ -282,6 +282,25 @@ jQuery(document).ready(
           }
       });
 
+      // Download the modified events
+      $('.container').on('click', 'button.download_events', function() {
+        var formEvents = [];
+        $('.formEvents').each(function() {
+          try {
+            formEvents.push(JSON.parse($(this).val()));
+          } catch (e) {
+            window.logMessages("Invalid json format :\n" + $(this).val());
+            return false;
+          }
+        });
+        if (formEvents.length !== 0) {
+          var jsonData = JSON.stringify(formEvents, null, 2);
+          downloadFile(jsonData, "application/json;charset=utf-8", "events.json");
+        } else {
+            window.logMessages("Data not available for download!");
+          }
+      });
+
       function getTemplate(name) {
         var request = new XMLHttpRequest();
         request.open("GET", frontendServiceUrl + '/download/' + name, true);

--- a/src/main/resources/templates/testRules.html
+++ b/src/main/resources/templates/testRules.html
@@ -103,14 +103,20 @@
         </div>
         <div class="row-fluid divpad" id="submitButton">
             <div class="row">
-                <div class="col-5">
+                <div class="col-4">
                     <button class="btn btn-success download_rules white-space-normal">
                         Download Rules
                         <i class="fa fa-fw  fa-download"></i>
                     </button>
                 </div>
-                <div class="col-7">
+                <div class="col-4 text-center">
                     <button class="btn btn-success find_aggregated_object white-space-normal" data-bind="click : $root.submit.bind($data)">Find Aggregated Object</button>
+                </div>
+                <div class="col-4">
+                    <button class="btn btn-success download_events white-space-normal float-right">
+                        Download Events
+                        <i class="fa fa-fw  fa-download"></i>
+                    </button>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
### Applicable Issues
In EI front end there is a buton to download rules, but there is missing a button to download the events.

### Description of the Change
I added the download button and fixed positions of all 3 buttons.

### Alternate Designs
None

### Benefits
It is possible now to download modified events.

### Possible Drawbacks
None

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Jakub Binieda, jakub.binieda@ericsson.com
