### PR TITLE
Shorter date column in subscription table

### DIFF
--- a/src/main/resources/static/js/subscription.js
+++ b/src/main/resources/static/js/subscription.js
@@ -196,9 +196,20 @@ jQuery(document).ready(function () {
         };
 
         self.getUTCDate = function (epochtime) {
-            var d = new Date(0); // The 0 there is the key, which sets the date to the epoch
-            d.setUTCMilliseconds(epochtime);
-            return d;  // Is now a date (in client time zone)
+            var date = new Date(epochtime);
+            var resolvedOptions = Intl.DateTimeFormat().resolvedOptions();
+            var options = {
+                    year: 'numeric',
+                    month: 'short',
+                    day: 'numeric',
+                    hour: 'numeric',
+                    minute: 'numeric',
+                    second: 'numeric',
+                    hour12: false,
+                    timeZone: resolvedOptions.timeZone,
+                    timeZoneName: 'short'
+            };
+            return date.toLocaleDateString(resolvedOptions.locale, options);  // Is now a date (in client time zone)
         }
 
         self.add_requirement = function (data, event) {


### PR DESCRIPTION
### Applicable Issues
The date column is quite long and verbose in the subscription table.
If anyone has feedback on the format please share.

### Description of the Change
Shorten the date column to something smaller.
It displays a different format depending on the locale.
Currently it looks something like this:
Mon Nov 12 2018 07:11:20 GMT+0100 (Central European Standard Time)
It will now display something like this instead:
(en-Us)
Nov 12, 2018, 07:11:20 GMT+1
(sv)
12 nov. 2018 07:11:20 CET

### Alternate Designs
Different date format

### Benefits
Less space taken by that column potentially allowing for more columns to be visible.

### Possible Drawbacks
--

### Sign-off
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Christoffer Cortes Sjöwall, christoffer.cortes.sjowall@ericsson.com
