### PR TITLE
Add replace/append functionality in TestRules

### DIFF
--- a/src/main/resources/static/js/testrules.js
+++ b/src/main/resources/static/js/testrules.js
@@ -1,6 +1,7 @@
 // Global vars
 var frontendServiceUrl;
 var i = 0;
+var isReplacing = false;
 var ruleTemplate = {
   "TemplateName" : "",
   "Type" : "",
@@ -189,91 +190,115 @@ jQuery(document).ready(
               sticky : false,
               theme : 'Notify'
             });
-            
+
             var list = JSON.parse(fileContent);
-            if (isRules == true) {
-                vm.rulesBindingList([]);
-                list.forEach(function(element) {
-                    vm.addRule(element);
-                });
+            if (isRules) {
+                if (isReplacing) {
+                    vm.rulesBindingList([]);
+                    list.forEach(function(element) {
+                        vm.addRule(element);
+                    });
+                } else {
+                    list.forEach(function(element) {
+                        vm.addRule(element);
+                    });
+                }
             } else {
-                vm.eventsBindingList([]);
-                list.forEach(function(element) {
-                    vm.addEvent(element);
-                });
+                if (isReplacing) {
+                    vm.eventsBindingList([]);
+                    list.forEach(function(element) {
+                        vm.addEvent(element);
+                    });
+                } else {
+                    list.forEach(function(element) {
+                        vm.addEvent(element);
+                    });
+                }
             }
           };
-          
+
           if (subscriptionFile != null){
             reader.readAsText(subscriptionFile);
           }
        }
 
-        //Set onchange event on the input element "uploadRulesFile" and "uploadEventsFile"
-        var pomRules = document.getElementById('uploadRulesFile');
-        pomRules.onchange = function uploadFinished() {
-            var subscriptionFile = pomRules.files[0];
-            validateJSONAndUpload(subscriptionFile, true);
-            $(this).val("");
-        };
-        
-        var pomEvents = document.getElementById('uploadEventsFile');
-        pomEvents.onchange = function uploadFinished() {
-            var subscriptionFile = pomEvents.files[0];
-            validateJSONAndUpload(subscriptionFile, false);
-            $(this).val("");
-        };
-          
+      //Set onchange event on the input element "uploadRulesFile" and "uploadEventsFile"
+      var pomRules = document.getElementById('uploadRulesFile');
+      pomRules.onchange = function uploadFinished() {
+        var subscriptionFile = pomRules.files[0];
+        validateJSONAndUpload(subscriptionFile, true);
+        $(this).val("");
+      };
+
+      var pomEvents = document.getElementById('uploadEventsFile');
+      pomEvents.onchange = function uploadFinished() {
+        var subscriptionFile = pomEvents.files[0];
+        validateJSONAndUpload(subscriptionFile, false);
+        $(this).val("");
+      };
+
       //Upload events list json data
       $(".container").on("click", "button.upload_rules", function(event) {
         event.stopPropagation();
         event.preventDefault();
+        var isRules = true;
+        replaceAppendModal(isRules);
 
-        function createRulesUploadWindow() {
-          if (document.createEvent) {
-            var event = document.createEvent('MouseEvents');
-            event.initEvent('click', true, true);
-            pomRules.dispatchEvent(event);
-          } else {
-            pomRules.click();
-          }
-        }
-        
-        function createUploadWindowMSExplorer() {
-          $('#upload_rules').click();
-          var file = $('#upload_rules').prop('files')[0];
-          validateJSONAndUpload(file, true);
-        }
-
-        // HTML5 Download File window handling
-        createRulesUploadWindow();
       });
 
-      //Upload list of events json data
+       //Upload list of events json data
       $(".container").on("click", "button.upload_events", function(event) {
         event.stopPropagation();
         event.preventDefault();
-
-        function createUploadWindow() {
-          if (document.createEvent) {
-            var event = document.createEvent('MouseEvents');
-            event.initEvent('click', true, true);
-            pomEvents.dispatchEvent(event);
-          } else {
-            pomEvents.click();
-          }
-        }
-
-        function createUploadWindowMSExplorer() {
-          $('#upload_events').click();
-          var file = $('#upload_events').prop('files')[0];
-          validateJSONAndUpload(file, false);
-        }
-
-
-        // HTML5 Download File window handling
-        createUploadWindow();
+        var isRules = false;
+        replaceAppendModal(isRules);
       });
+
+      function replaceAppendModal(isRules){
+        $('#AppendReplaceModal').modal('show');
+
+        document.getElementById('replaceButton').onclick = function(){
+            $('#AppendReplaceModal').modal('hide');
+            if(isRules){
+                isReplacing = true;
+                createRulesUploadWindow();
+            }else{
+                isReplacing = true;
+                createUploadWindow();
+            }
+        };
+
+        document.getElementById('appendButton').onclick = function(){
+            $('#AppendReplaceModal').modal('hide');
+            if(isRules){
+                isReplacing = false;
+                createRulesUploadWindow();
+            }else{
+                isReplacing = false;
+                createUploadWindow();
+            }
+        };
+      }
+
+     function createRulesUploadWindow() {
+        if (document.createEvent) {
+          var event = document.createEvent('MouseEvents');
+          event.initEvent('click', true, true);
+          pomRules.dispatchEvent(event);
+        } else {
+          pomRules.click();
+        }
+      }
+
+      function createUploadWindow() {
+        if (document.createEvent) {
+          var event = document.createEvent('MouseEvents');
+          event.initEvent('click', true, true);
+          pomEvents.dispatchEvent(event);
+        } else {
+          pomEvents.click();
+        }
+      }
 
       // Download the modified rule
       $('.container').on('click', 'button.download_rules', function() {

--- a/src/main/resources/static/js/testrules.js
+++ b/src/main/resources/static/js/testrules.js
@@ -1,7 +1,7 @@
 // Global vars
 var frontendServiceUrl;
 var i = 0;
-var isReplacing = false;
+var isReplacing = true;
 var ruleTemplate = {
   "TemplateName" : "",
   "Type" : "",

--- a/src/main/resources/static/js/testrules.js
+++ b/src/main/resources/static/js/testrules.js
@@ -195,25 +195,17 @@ jQuery(document).ready(
             if (isRules) {
                 if (isReplacing) {
                     vm.rulesBindingList([]);
-                    list.forEach(function(element) {
-                        vm.addRule(element);
-                    });
-                } else {
-                    list.forEach(function(element) {
-                        vm.addRule(element);
-                    });
                 }
+                list.forEach(function(element) {
+                    vm.addRule(element);
+                });
             } else {
                 if (isReplacing) {
                     vm.eventsBindingList([]);
-                    list.forEach(function(element) {
-                        vm.addEvent(element);
-                    });
-                } else {
-                    list.forEach(function(element) {
-                        vm.addEvent(element);
-                    });
                 }
+                list.forEach(function(element) {
+                    vm.addEvent(element);
+                });
             }
           };
 
@@ -259,22 +251,20 @@ jQuery(document).ready(
 
         document.getElementById('replaceButton').onclick = function(){
             $('#AppendReplaceModal').modal('hide');
+            isReplacing = true;
             if(isRules){
-                isReplacing = true;
                 createRulesUploadWindow();
             }else{
-                isReplacing = true;
                 createUploadWindow();
             }
         };
 
         document.getElementById('appendButton').onclick = function(){
             $('#AppendReplaceModal').modal('hide');
+            isReplacing = false;
             if(isRules){
-                isReplacing = false;
                 createRulesUploadWindow();
             }else{
-                isReplacing = false;
                 createUploadWindow();
             }
         };

--- a/src/main/resources/templates/testRules.html
+++ b/src/main/resources/templates/testRules.html
@@ -136,7 +136,7 @@
 	      </div>
 	      <div class="modal-footer justify-content-center">
             <button id="replaceButton" type="button" class="btn btn-primary">Replace</button>
-            <button id="appendButton" type="button" class="btn btn-secondary">Append</button>
+            <button id="appendButton" type="button" class="btn btn-info">Append</button>
 	      </div>
 	    </div>
 	  </div>

--- a/src/main/resources/templates/testRules.html
+++ b/src/main/resources/templates/testRules.html
@@ -20,8 +20,8 @@
             <div class="p-1 col-lg-6 col-md-6 col-12 border border-right border-success" id="testRulesDOMObject">
                 <div class="d-flex flex-wrap">
 	                <div class="col-11">
-	                   <button class="btn btn-primary upload_rules rule-button mr-1 mt-1 d-inline-block">
-                           Upload Rules
+	                   <button class="btn btn-primary upload_rules mr-1 mt-1 d-inline-block">
+                           Load Rules from file
                            <i class="fa fa-fw  fa-upload"></i>
                        </button>
                        <input class="hide" type='file' id='uploadRulesFile' name='file'/>
@@ -65,8 +65,8 @@
             <div class="p-1 col-lg-6 col-md-6 col-12 border border-right border-success" id="testEventsDOMObject">
                 <div class="d-flex flex-wrap">
                     <div class="col-11">
-                       <button class="btn btn-primary upload_events rule-button mr-1 mt-1 d-inline-block">
-                           Upload Events
+                       <button class="btn btn-primary upload_events mr-1 mt-1 d-inline-block">
+                           Load Events from file
                            <i class="fa fa-fw  fa-upload"></i>
                        </button>
                        <input class="hide" type='file' id='uploadEventsFile' name='file'/>
@@ -128,6 +128,19 @@
             </div>
         </div>
     </div>
+    <div id="AppendReplaceModal" class="modal fade" role="dialog">
+	  <div class="modal-dialog" role="document">
+	    <div class="modal-content">
+	      <div class="modal-header justify-content-center">
+	        <h5 class="modal-title">Do you want to replace or append?</h5>
+	      </div>
+	      <div class="modal-footer justify-content-center">
+            <button id="replaceButton" type="button" class="btn btn-primary">Replace</button>
+            <button id="appendButton" type="button" class="btn btn-secondary">Append</button>
+	      </div>
+	    </div>
+	  </div>
+	</div>
     <div id="aggregatedObjectModal" class="modal fade" role="dialog">
 	  <div class="modal-dialog modal-width-aggregated" role="document">
 	    <div class="modal-content">


### PR DESCRIPTION
### Applicable Issues
The test rules page in eiffel intelligence frontend needs to change to improve usability.

### Description of the Change
Changed "Upload rules" button name to "Load rules from file", so that user do not confuse this with transferring rules to a remote storage/cloud

Created a pop-up when "Loading rules from file" where the user gets the question to replace or append the loaded rules/events with the previous created rules/events.

Implemented the functionality for replacing and appending loaded rules.

### Alternate Designs
None

### Benefits
It is possible now to choose if you want to replace or append rules/events when you upload.

### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Jakub Binieda, jakub.binieda@ericsson.com
