### PR TITLE
Improve EI Backend instances list configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,7 @@ before_install:
   - chmod +x pom.xml
   
 script:
+  - sudo add-apt-repository -y ppa:webupd8team/java
+  - sudo apt-get update
+  - sudo apt-get install -y oracle-java8-installer || true
   - mvn test

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,7 @@ language: java
 services: 
 
 dist:
-  - xenial
-
-packages:
-  - oracle-java8-installer
-  - oracle-java8-set-default
+  - trusty
 
 jdk:
   - oraclejdk8
@@ -18,7 +14,4 @@ before_install:
   - chmod +x pom.xml
   
 script:
-  - sudo add-apt-repository -y ppa:webupd8team/java
-  - sudo apt-get update
-  - sudo apt-get install -y oracle-java8-installer || true
   - mvn test

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,6 @@ language: java
 
 services: 
 
-dist:
-  - trusty
-
 jdk:
   - oraclejdk8
   

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,4 @@ before_install:
   - chmod +x pom.xml
   
 script:
-  - mvn test
+  - mvn test -q

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,4 @@ before_install:
   - chmod +x pom.xml
   
 script:
-  - mvn test -q
+  - mvn test

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ language: java
 
 services: 
 
+dist:
+  - xenial
+
 jdk:
   - oraclejdk8
   

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>com.github.ericsson</groupId>
   <artifactId>eiffel-intelligence-frontend</artifactId>
-  <version>0.0.16</version>
+  <version>0.0.17</version>
   <packaging>war</packaging>
   <parent>
     <groupId>org.springframework.boot</groupId>

--- a/src/main/java/com/ericsson/ei/frontend/model/BackEndInformation.java
+++ b/src/main/java/com/ericsson/ei/frontend/model/BackEndInformation.java
@@ -16,9 +16,9 @@
 */
 package com.ericsson.ei.frontend.model;
 
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+import com.ericsson.ei.frontend.utils.BackEndInstancesUtils;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.gson.JsonObject;
 import com.google.gson.annotations.SerializedName;
@@ -36,17 +36,11 @@ import lombok.ToString;
 @NoArgsConstructor
 @AllArgsConstructor
 public class BackEndInformation {
-    private static final String NAME = "name";
-    private static final String HOST = "host";
-    private static final String PORT = "port";
-    private static final String PATH = "path";
-    private static final String HTTPS = "https";
-    private static final String DEFAULT = "defaultBackend";
 
     private String name;
     private String host;
     private String port;
-    private String path;
+    private String contextPath;
 
     @JsonProperty("https")
     @SerializedName("https")
@@ -62,12 +56,12 @@ public class BackEndInformation {
      */
     public JsonObject getAsJsonObject() {
         JsonObject instance = new JsonObject();
-        instance.addProperty(NAME, name);
-        instance.addProperty(HOST, host);
-        instance.addProperty(PORT, Integer.valueOf(port));
-        instance.addProperty(PATH, path);
-        instance.addProperty(HTTPS, useSecureHttpBackend);
-        instance.addProperty(DEFAULT, defaultBackend);
+        instance.addProperty(BackEndInstancesUtils.NAME, name);
+        instance.addProperty(BackEndInstancesUtils.HOST, host);
+        instance.addProperty(BackEndInstancesUtils.PORT, Integer.valueOf(port));
+        instance.addProperty(BackEndInstancesUtils.CONTEXT_PATH, contextPath);
+        instance.addProperty(BackEndInstancesUtils.HTTPS, useSecureHttpBackend);
+        instance.addProperty(BackEndInstancesUtils.DEFAULT, defaultBackend);
         return instance;
     }
 
@@ -85,8 +79,8 @@ public class BackEndInformation {
 
         constructedUrl += "://" + host + ":" + port;
 
-        if (this.getPath() != null && !this.getPath().isEmpty()) {
-            constructedUrl += ("/" + path).replaceAll("//", "/");
+        if (this.getContextPath() != null && !this.getContextPath().isEmpty()) {
+            constructedUrl += ("/" + contextPath).replaceAll("//", "/");
         }
 
         return constructedUrl;

--- a/src/main/java/com/ericsson/ei/frontend/model/BackEndInformation.java
+++ b/src/main/java/com/ericsson/ei/frontend/model/BackEndInformation.java
@@ -43,19 +43,11 @@ public class BackEndInformation {
     private static final String HTTPS = "https";
     private static final String DEFAULT = "defaultBackend";
 
-    @Value("${ei.backendServerName:#{null}}")
     private String name;
-
-    @Value("${ei.backendServerHost:#{null}}")
     private String host;
-
-    @Value("${ei.backendServerPort:#{null}}")
     private String port;
-
-    @Value("${ei.backendContextPath:#{\"\"}}")
     private String path;
 
-    @Value("${ei.useSecureHttpBackend:#{false}}")
     @JsonProperty("https")
     @SerializedName("https")
     private boolean useSecureHttpBackend;

--- a/src/main/java/com/ericsson/ei/frontend/utils/BackEndInfoirmationControllerUtils.java
+++ b/src/main/java/com/ericsson/ei/frontend/utils/BackEndInfoirmationControllerUtils.java
@@ -68,7 +68,7 @@ public class BackEndInfoirmationControllerUtils {
         } catch (Exception e) {
             LOG.error("ERROR!\n" + e.getMessage());
             return new ResponseEntity<>(
-                    "[{\"name\":\"Unable to load instances\",\"host\":\"NO HOST\",\"port\":\"NO PORT\",\"path\":\"/\"}]",
+                    "[{\"name\":\"Unable to load instances\",\"host\":\"NO HOST\",\"port\":\"NO PORT\",\"contextPath\":\"/\"}]",
                     getHeaders(), HttpStatus.OK);
         }
     }

--- a/src/main/java/com/ericsson/ei/frontend/utils/BackEndInstanceFileUtils.java
+++ b/src/main/java/com/ericsson/ei/frontend/utils/BackEndInstanceFileUtils.java
@@ -14,6 +14,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+import com.ericsson.ei.frontend.model.BackEndInformation;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
@@ -83,11 +84,11 @@ public class BackEndInstanceFileUtils {
     	for (JsonElement instanceJsonObj : jArray) {
     		JsonObject jObject = instanceJsonObj.getAsJsonObject();
     		if (Boolean.getBoolean(jObject.get("defaultBackend").toString())) {
-    			backendInstancesUtils.setDefaultBackEndInstance(jObject.get("name").toString(),
-    					jObject.get("host").toString(),
-    					Integer.parseInt(jObject.get("port").toString()),
-    					jObject.get("path").toString(),
-    					Boolean.getBoolean(jObject.get("defaultBackend").toString()));
+    			backendInstancesUtils.setDefaultBackEndInstance(jObject.get(BackEndInstancesUtils.NAME).toString(),
+    					jObject.get(BackEndInstancesUtils.HOST).toString(),
+    					Integer.parseInt(jObject.get(BackEndInstancesUtils.PORT).toString()),
+    					jObject.get(BackEndInstancesUtils.CONTEXT_PATH).toString(),
+    					Boolean.getBoolean(jObject.get(BackEndInstancesUtils.DEFAULT).toString()));
     		}
     	}
     }

--- a/src/main/java/com/ericsson/ei/frontend/utils/BackEndInstanceFileUtils.java
+++ b/src/main/java/com/ericsson/ei/frontend/utils/BackEndInstanceFileUtils.java
@@ -7,7 +7,6 @@ import java.nio.file.Paths;
 
 import javax.annotation.PostConstruct;
 
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -36,10 +35,10 @@ public class BackEndInstanceFileUtils {
 
     @Autowired
     BackEndInstancesUtils backendInstancesUtils;
-    
+
     @Value("${ei.backendInstancesFilePath:#{null}}")
     private String backendInstancesFilePath;
-    
+
     @Value("${ei.backendInstancesListJsonContent:#{null}}")
     private String backendInstancesListJsonContent;
 
@@ -47,9 +46,8 @@ public class BackEndInstanceFileUtils {
     public void init() throws IOException {
         LOG.info("Initiating BackEndInstanceFileUtils.");
 
-
         // Use home folder if a specific backendInstancesFilePath isn't provided
-        if(backendInstancesFilePath == null || backendInstancesFilePath.isEmpty()) {
+        if (backendInstancesFilePath == null || backendInstancesFilePath.isEmpty()) {
 
             String homeFolder = System.getProperty("user.home");
             String eiHome = Paths.get(homeFolder, EI_HOME_DEFAULT_NAME).toString();
@@ -60,30 +58,28 @@ public class BackEndInstanceFileUtils {
             }
 
             setEiInstancesPath(Paths.get(eiHome, BACKEND_INSTANCES_DEFAULT_FILENAME).toString());
-            LOG.info("EI Instances List file path is not provided! " +
-                     "Will create a default EI Instances List file at file path: " + eiInstancesPath);
-            
+            LOG.info("EI Instances List file path is not provided! "
+                    + "Will create a default EI Instances List file at file path: " + eiInstancesPath);
+
             parseAndSetEiInstancesList();
-            
+
         } else {
             setEiInstancesPath(Paths.get(backendInstancesFilePath).toString());
             if (!(new File(eiInstancesPath).isFile())) {
-            	LOG.info("EI Instances List file don' exist! Creating file with given or " +
-                         "default EI instances list content. File path: " + eiInstancesPath);
+                LOG.info("EI Instances List file don' exist! Creating file with given or "
+                        + "default EI instances list content. File path: " + eiInstancesPath);
                 createFileWithDirs();
                 parseAndSetEiInstancesList();
+            } else {
+                LOG.info("EI-Backend instances list file that will be used: " + eiInstancesPath);
             }
-            else {
-            	LOG.info("EI-Backend instances list file that will be used: " + eiInstancesPath);
-            }
-            
+
         }
     }
 
-
     /**
-     * Parses Ei Instances list from backendInstancesListJsonContent property
-     * and sets default EI-Backend instance.
+     * Parses Ei Instances list from backendInstancesListJsonContent property and
+     * sets default EI-Backend instance.
      * 
      */
     private void parseAndSetEiInstancesList() {
@@ -91,45 +87,40 @@ public class BackEndInstanceFileUtils {
         parsedBackendInstancesListJsonArray = parseEiInstancesListJsonObject();
         dumpJsonArray(parsedBackendInstancesListJsonArray);
         try {
-			ensureValidFile();
-		} catch (IOException e) {
-			     LOG.error("Failed to validate EI Instances List json object." +
-		               "\nError message: " + e.getMessage() +
-		               "\nErrors: " + e);
-		}
+            ensureValidFile();
+        } catch (IOException e) {
+            LOG.error("Failed to validate EI Instances List json object." + "\nError message: " + e.getMessage()
+                    + "\nErrors: " + e);
+        }
         setDefaultEiBackendInstance(parsedBackendInstancesListJsonArray);
     }
-
 
     /**
      * Parses Ei Instances list from backendInstancesListJsonContent property.
      * 
-     * @return
-     *      JsonArray
+     * @return JsonArray
      */
     private JsonArray parseEiInstancesListJsonObject() {
         JsonArray backendInstancesListJsonArray = null;
-        
-        if ( backendInstancesListJsonContent == null || backendInstancesListJsonContent.isEmpty()) {
-        	LOG.error("EI backned instances list json object is empty, can't continue." +
-                      "\nMake sure that EI Instances list flags is set, " +
-        			  " 'ei.backendInstancesFilePath' or 'ei.backendInstancesListJsonContent'");
-      	System.exit(1);
+
+        if (backendInstancesListJsonContent == null || backendInstancesListJsonContent.isEmpty()) {
+            LOG.error("EI backned instances list json object is empty, can't continue."
+                    + "\nMake sure that EI Instances list flags is set, "
+                    + " 'ei.backendInstancesFilePath' or 'ei.backendInstancesListJsonContent'");
+            System.exit(1);
         }
-        
+
         try {
-        	backendInstancesListJsonArray = (JsonArray) new JsonParser().parse(backendInstancesListJsonContent.toString());
-        }
-        catch (JsonSyntaxException e) {
-        	LOG.error("Failed to parse EI backned instances list json object." +
-                      "\nMake sure ei.backendInstancesListJsonContent properties is set with one or more EI Backend instances." +
-        			  "\nError message: " + e.getMessage() +
-        			  "\nErrors: " + e);
-        	System.exit(1);
+            backendInstancesListJsonArray = (JsonArray) new JsonParser()
+                    .parse(backendInstancesListJsonContent.toString());
+        } catch (JsonSyntaxException e) {
+            LOG.error("Failed to parse EI backned instances list json object."
+                    + "\nMake sure ei.backendInstancesListJsonContent properties is set with one or more EI Backend instances."
+                    + "\nError message: " + e.getMessage() + "\nErrors: " + e);
+            System.exit(1);
         }
         return backendInstancesListJsonArray;
     }
-
 
     /**
      * Sets default EI Backend instance.
@@ -140,25 +131,25 @@ public class BackEndInstanceFileUtils {
             JsonObject jObject = instanceJsonObj.getAsJsonObject();
             if (Boolean.getBoolean(jObject.get("defaultBackend").toString())) {
                 backendInstancesUtils.setDefaultBackEndInstance(jObject.get(BackEndInstancesUtils.NAME).toString(),
-                jObject.get(BackEndInstancesUtils.HOST).toString(),
-                Integer.parseInt(jObject.get(BackEndInstancesUtils.PORT).toString()),
-                jObject.get(BackEndInstancesUtils.CONTEXT_PATH).toString(),
-                Boolean.getBoolean(jObject.get(BackEndInstancesUtils.DEFAULT).toString()));
+                        jObject.get(BackEndInstancesUtils.HOST).toString(),
+                        Integer.parseInt(jObject.get(BackEndInstancesUtils.PORT).toString()),
+                        jObject.get(BackEndInstancesUtils.CONTEXT_PATH).toString(),
+                        Boolean.getBoolean(jObject.get(BackEndInstancesUtils.DEFAULT).toString()));
             }
         }
     }
 
     /**
-     *Gets the JSON-data from file and returns as a JsonArray
+     * Gets the JSON-data from file and returns as a JsonArray
      *
-     * @return
-     *      JsonArray
+     * @return JsonArray
      */
     public JsonArray getInstancesFromFile() {
         try {
             ensureValidFile();
 
-            JsonArray inputBackEndInstances = new JsonParser().parse(new String(Files.readAllBytes(Paths.get(eiInstancesPath)))).getAsJsonArray();
+            JsonArray inputBackEndInstances = new JsonParser()
+                    .parse(new String(Files.readAllBytes(Paths.get(eiInstancesPath)))).getAsJsonArray();
             return inputBackEndInstances;
         } catch (IOException e) {
             LOG.error("Failure when try to parse json file" + e.getMessage());
@@ -169,8 +160,7 @@ public class BackEndInstanceFileUtils {
     /**
      * Saves the given JsonArray
      *
-     * @param jsonArrayToDump
-     *      JsonArray
+     * @param jsonArrayToDump JsonArray
      */
     public void dumpJsonArray(JsonArray jsonArrayToDump) {
         try {
@@ -190,12 +180,14 @@ public class BackEndInstanceFileUtils {
             }
 
             if (!fileContainsJsonArray()) {
-                LOG.error("File does not contain valid json! JSON:'" + new String(Files.readAllBytes(Paths.get(eiInstancesPath))) + "'.");
+                LOG.error("File does not contain valid json! JSON:'"
+                        + new String(Files.readAllBytes(Paths.get(eiInstancesPath))) + "'.");
                 System.exit(-1);
             }
-        } catch(Exception e) {
+        } catch (Exception e) {
             String message = String.format(
-                    "Failed to read backendInstancesFilePath %s. Please check access rights or choose another backendInstancesFilePath in application.properties.", eiInstancesPath);
+                    "Failed to read backendInstancesFilePath %s. Please check access rights or choose another backendInstancesFilePath in application.properties.",
+                    eiInstancesPath);
             LOG.error(message);
             System.exit(-1);
         }
@@ -204,8 +196,9 @@ public class BackEndInstanceFileUtils {
     private void createFileWithDirs() throws IOException {
         File eiInstancesParentFolder = Paths.get(eiInstancesPath).getParent().toFile();
 
-        if (!(eiInstancesParentFolder.isDirectory())){
-            LOG.info(String.format("Parentdir(s) for %s does not exist! Trying to create necessary parent dirs.", backendInstancesFilePath));
+        if (!(eiInstancesParentFolder.isDirectory())) {
+            LOG.info(String.format("Parentdir(s) for %s does not exist! Trying to create necessary parent dirs.",
+                    backendInstancesFilePath));
             eiInstancesParentFolder.mkdirs();
         }
 
@@ -229,7 +222,8 @@ public class BackEndInstanceFileUtils {
 
         if (!success) {
             String message = String.format(
-                    "Failed to create eiffel intelligence home folder in %s. Please check access rights or choose a specific backendInstancesFilePath in application.properties.", eiHome);
+                    "Failed to create eiffel intelligence home folder in %s. Please check access rights or choose a specific backendInstancesFilePath in application.properties.",
+                    eiHome);
             LOG.error(message);
             System.exit(-1);
         }

--- a/src/main/java/com/ericsson/ei/frontend/utils/BackEndInstanceFileUtils.java
+++ b/src/main/java/com/ericsson/ei/frontend/utils/BackEndInstanceFileUtils.java
@@ -86,6 +86,9 @@ public class BackEndInstanceFileUtils {
                 dumpJsonArray(backendInstancesListJsonArray);
                 ensureValidFile();
             }
+            else {
+            	LOG.info("EI-Bakend instances list file that will be used: " + eiInstancesPath);
+            }
             
         }
     }

--- a/src/main/java/com/ericsson/ei/frontend/utils/BackEndInstanceFileUtils.java
+++ b/src/main/java/com/ericsson/ei/frontend/utils/BackEndInstanceFileUtils.java
@@ -61,7 +61,8 @@ public class BackEndInstanceFileUtils {
             }
 
             setEiInstancesPath(Paths.get(eiHome, BACKEND_INSTANCES_DEFAULT_FILENAME).toString());
-            
+            LOG.info("EI Instances List file path is not provided! " +
+                     "Will create a default EI Instances List file at file path: " + eiInstancesPath);
             dumpJsonArray(backendInstancesListJsonArray);
             ensureValidFile();
             setDefaultEiBackendInstance(backendInstancesListJsonArray);
@@ -69,6 +70,8 @@ public class BackEndInstanceFileUtils {
         } else {
             setEiInstancesPath(Paths.get(backendInstancesFilePath).toString());
             if (!(new File(eiInstancesPath).isFile())) {
+            	LOG.info("EI Instances List file don' exist! Creating file with given or " +
+                         "default EI instances list content. File path: " + eiInstancesPath);
                 createFileWithDirs();
                 dumpJsonArray(backendInstancesListJsonArray);
                 ensureValidFile();

--- a/src/main/java/com/ericsson/ei/frontend/utils/BackEndInstanceFileUtils.java
+++ b/src/main/java/com/ericsson/ei/frontend/utils/BackEndInstanceFileUtils.java
@@ -79,8 +79,13 @@ public class BackEndInstanceFileUtils {
             
         }
     }
-    
-    
+
+
+    /**
+     * Parses Ei Instances list from backendInstancesListJsonContent property
+     * and sets default EI-Backend instance.
+     * 
+     */
     private void parseAndSetEiInstancesList() {
         JsonArray parsedBackendInstancesListJsonArray = null;
         parsedBackendInstancesListJsonArray = parseEiInstancesListJsonObject();
@@ -94,7 +99,14 @@ public class BackEndInstanceFileUtils {
 		}
         setDefaultEiBackendInstance(parsedBackendInstancesListJsonArray);
     }
-    
+
+
+    /**
+     * Parses Ei Instances list from backendInstancesListJsonContent property.
+     * 
+     * @return
+     *      JsonArray
+     */
     private JsonArray parseEiInstancesListJsonObject() {
         JsonArray backendInstancesListJsonArray = null;
         
@@ -117,7 +129,12 @@ public class BackEndInstanceFileUtils {
         }
         return backendInstancesListJsonArray;
     }
-    
+
+
+    /**
+     * Sets default EI Backend instance.
+     *
+     */
     private void setDefaultEiBackendInstance(JsonArray jArray) {
     	for (JsonElement instanceJsonObj : jArray) {
     		JsonObject jObject = instanceJsonObj.getAsJsonObject();

--- a/src/main/java/com/ericsson/ei/frontend/utils/BackEndInstanceFileUtils.java
+++ b/src/main/java/com/ericsson/ei/frontend/utils/BackEndInstanceFileUtils.java
@@ -7,8 +7,7 @@ import java.nio.file.Paths;
 
 import javax.annotation.PostConstruct;
 
-import org.json.JSONArray;
-import org.json.JSONObject;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/main/java/com/ericsson/ei/frontend/utils/BackEndInstanceFileUtils.java
+++ b/src/main/java/com/ericsson/ei/frontend/utils/BackEndInstanceFileUtils.java
@@ -93,7 +93,7 @@ public class BackEndInstanceFileUtils {
         try {
 			ensureValidFile();
 		} catch (IOException e) {
-			LOG.error("Failed to validate EI Instances List json object." +
+			     LOG.error("Failed to validate EI Instances List json object." +
 		               "\nError message: " + e.getMessage() +
 		               "\nErrors: " + e);
 		}

--- a/src/main/java/com/ericsson/ei/frontend/utils/BackEndInstanceFileUtils.java
+++ b/src/main/java/com/ericsson/ei/frontend/utils/BackEndInstanceFileUtils.java
@@ -3,6 +3,7 @@ package com.ericsson.ei.frontend.utils;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import javax.annotation.PostConstruct;
@@ -56,12 +57,25 @@ public class BackEndInstanceFileUtils {
             if (!eiHomeExists) {
                 createEiHomeFolder(eiHome);
             }
-
-            setEiInstancesPath(Paths.get(eiHome, BACKEND_INSTANCES_DEFAULT_FILENAME).toString());
-            LOG.info("EI Instances List file path is not provided! "
-                    + "Will create a default EI Instances List file at file path: " + eiInstancesPath);
-
-            parseAndSetEiInstancesList();
+            
+            Path eiInstancesListFilePath = Paths.get(eiHome, BACKEND_INSTANCES_DEFAULT_FILENAME);
+            setEiInstancesPath(eiInstancesListFilePath.toString());
+            File eiInstancesListFile = new File(eiInstancesListFilePath.toString());
+            if (eiInstancesListFile.exists() && eiInstancesListFile.length() != 0) {
+                LOG.info("EI Instances List file path is not provided, but found a file in path: "  + eiInstancesPath +
+                        "\nWill use that EI Instances List file.");
+            }
+            else {
+                if (eiInstancesListFile.exists() && eiInstancesListFile.length() == 0) {
+                    LOG.info("EI Instances List file path is not provided, but found a file in path: "  + eiInstancesPath +
+                            "\nThat EI Instances List file is empty!. Will try to create a default EI Instances List in that file.");
+                }
+                else {
+                    LOG.info("EI Instances List file path is not provided! " +
+                            "Will create a default EI Instances List file at file path: " + eiInstancesPath);
+                }
+                parseAndSetEiInstancesList();
+            }
 
         } else {
             setEiInstancesPath(Paths.get(backendInstancesFilePath).toString());
@@ -164,7 +178,6 @@ public class BackEndInstanceFileUtils {
      */
     public void dumpJsonArray(JsonArray jsonArrayToDump) {
         try {
-            ensureValidFile();
             Files.write(Paths.get(eiInstancesPath), jsonArrayToDump.toString().getBytes());
         } catch (IOException e) {
             LOG.error("Couldn't add instance to file " + e.getMessage());
@@ -180,7 +193,7 @@ public class BackEndInstanceFileUtils {
             }
 
             if (!fileContainsJsonArray()) {
-                LOG.error("File does not contain valid json! JSON:'"
+                LOG.error("File does not contain valid json! JSON:' "
                         + new String(Files.readAllBytes(Paths.get(eiInstancesPath))) + "'.");
                 System.exit(-1);
             }

--- a/src/main/java/com/ericsson/ei/frontend/utils/BackEndInstanceFileUtils.java
+++ b/src/main/java/com/ericsson/ei/frontend/utils/BackEndInstanceFileUtils.java
@@ -46,6 +46,8 @@ public class BackEndInstanceFileUtils {
     public void init() throws IOException {
         LOG.info("Initiating BackEndInstanceFileUtils.");
 
+        JsonArray backendInstancesListJsonArray = (JsonArray) new JsonParser().parse(backendInstancesListJsonContent.toString());
+
 
         // Use home folder if a specific backendInstancesFilePath isn't provided
         if(backendInstancesFilePath == null || backendInstancesFilePath.isEmpty()) {
@@ -59,21 +61,24 @@ public class BackEndInstanceFileUtils {
             }
 
             setEiInstancesPath(Paths.get(eiHome, BACKEND_INSTANCES_DEFAULT_FILENAME).toString());
-            System.out.println("FILE_CONTENT: " +  backendInstancesListJsonContent);
-            JsonArray jArray = (JsonArray) new JsonParser().parse(backendInstancesListJsonContent.toString());
             
-            dumpJsonArray(jArray);
+            dumpJsonArray(backendInstancesListJsonArray);
             ensureValidFile();
-            setDefaultEiBackendInstance(jArray);
+            setDefaultEiBackendInstance(backendInstancesListJsonArray);
             
         } else {
             setEiInstancesPath(Paths.get(backendInstancesFilePath).toString());
+            if (!(new File(eiInstancesPath).isFile())) {
+                createFileWithDirs();
+                dumpJsonArray(backendInstancesListJsonArray);
+                ensureValidFile();
+            }
+            
         }
     }
     
     private void setDefaultEiBackendInstance(JsonArray jArray) {
     	for (JsonElement instanceJsonObj : jArray) {
-    		System.out.println("KALLE: " + instanceJsonObj);
     		JsonObject jObject = instanceJsonObj.getAsJsonObject();
     		if (Boolean.getBoolean(jObject.get("defaultBackend").toString())) {
     			backendInstancesUtils.setDefaultBackEndInstance(jObject.get("name").toString(),

--- a/src/main/java/com/ericsson/ei/frontend/utils/BackEndInstanceFileUtils.java
+++ b/src/main/java/com/ericsson/ei/frontend/utils/BackEndInstanceFileUtils.java
@@ -136,16 +136,16 @@ public class BackEndInstanceFileUtils {
      *
      */
     private void setDefaultEiBackendInstance(JsonArray jArray) {
-    	for (JsonElement instanceJsonObj : jArray) {
-    		JsonObject jObject = instanceJsonObj.getAsJsonObject();
-    		if (Boolean.getBoolean(jObject.get("defaultBackend").toString())) {
-    			backendInstancesUtils.setDefaultBackEndInstance(jObject.get(BackEndInstancesUtils.NAME).toString(),
-    					jObject.get(BackEndInstancesUtils.HOST).toString(),
-    					Integer.parseInt(jObject.get(BackEndInstancesUtils.PORT).toString()),
-    					jObject.get(BackEndInstancesUtils.CONTEXT_PATH).toString(),
-    					Boolean.getBoolean(jObject.get(BackEndInstancesUtils.DEFAULT).toString()));
-    		}
-    	}
+        for (JsonElement instanceJsonObj : jArray) {
+            JsonObject jObject = instanceJsonObj.getAsJsonObject();
+            if (Boolean.getBoolean(jObject.get("defaultBackend").toString())) {
+                backendInstancesUtils.setDefaultBackEndInstance(jObject.get(BackEndInstancesUtils.NAME).toString(),
+                jObject.get(BackEndInstancesUtils.HOST).toString(),
+                Integer.parseInt(jObject.get(BackEndInstancesUtils.PORT).toString()),
+                jObject.get(BackEndInstancesUtils.CONTEXT_PATH).toString(),
+                Boolean.getBoolean(jObject.get(BackEndInstancesUtils.DEFAULT).toString()));
+            }
+        }
     }
 
     /**

--- a/src/main/java/com/ericsson/ei/frontend/utils/BackEndInstanceFileUtils.java
+++ b/src/main/java/com/ericsson/ei/frontend/utils/BackEndInstanceFileUtils.java
@@ -104,7 +104,7 @@ public class BackEndInstanceFileUtils {
         JsonArray backendInstancesListJsonArray = null;
 
         if (backendInstancesListJsonContent == null || backendInstancesListJsonContent.isEmpty()) {
-            LOG.error("EI backned instances list json object is empty, can't continue."
+            LOG.error("EI backend instances list json object is empty, can't continue."
                     + "\nMake sure that EI Instances list flags is set, "
                     + " 'ei.backendInstancesFilePath' or 'ei.backendInstancesListJsonContent'");
             System.exit(1);
@@ -114,8 +114,8 @@ public class BackEndInstanceFileUtils {
             backendInstancesListJsonArray = (JsonArray) new JsonParser()
                     .parse(backendInstancesListJsonContent.toString());
         } catch (JsonSyntaxException e) {
-            LOG.error("Failed to parse EI backned instances list json object."
-                    + "\nMake sure ei.backendInstancesListJsonContent properties is set with one or more EI Backend instances."
+            LOG.error("Failed to parse EI backend instances list json object."
+                    + "\nMake sure ei.backendInstancesListJsonContent property is set with one or more EI Backend instances."
                     + "\nError message: " + e.getMessage() + "\nErrors: " + e);
             System.exit(1);
         }

--- a/src/main/java/com/ericsson/ei/frontend/utils/BackEndInstanceFileUtils.java
+++ b/src/main/java/com/ericsson/ei/frontend/utils/BackEndInstanceFileUtils.java
@@ -19,6 +19,7 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import com.google.gson.JsonSyntaxException;
 
 import lombok.Setter;
 
@@ -46,8 +47,17 @@ public class BackEndInstanceFileUtils {
     public void init() throws IOException {
         LOG.info("Initiating BackEndInstanceFileUtils.");
 
-        JsonArray backendInstancesListJsonArray = (JsonArray) new JsonParser().parse(backendInstancesListJsonContent.toString());
-
+        JsonArray backendInstancesListJsonArray = null;
+        try {
+        	backendInstancesListJsonArray = (JsonArray) new JsonParser().parse(backendInstancesListJsonContent.toString());
+        }
+        catch (JsonSyntaxException e) {
+        	LOG.error("Failed to parse EI backned instances list json object." +
+                      "\nMake sure ei.backendInstancesListJsonContent properties is set with one or more EI Backend instances." +
+        			  "\nError message: " + e.getMessage() +
+        			  "\nErrors: " + e);
+        	System.exit(1);
+        }
 
         // Use home folder if a specific backendInstancesFilePath isn't provided
         if(backendInstancesFilePath == null || backendInstancesFilePath.isEmpty()) {

--- a/src/main/java/com/ericsson/ei/frontend/utils/BackEndInstancesUtils.java
+++ b/src/main/java/com/ericsson/ei/frontend/utils/BackEndInstancesUtils.java
@@ -40,12 +40,15 @@ import lombok.Setter;
 @Component
 public class BackEndInstancesUtils {
 
-    private static final Logger LOG = LoggerFactory.getLogger(BackEndInstancesUtils.class);
-    private static final String NAME = "name";
-    private static final String HOST = "host";
-    private static final String PORT = "port";
-    private static final String PATH = "path";
-    private static final String HTTPS = "https";
+	private static final Logger LOG = LoggerFactory.getLogger(BackEndInstancesUtils.class);
+    
+	public static final String NAME = "name";
+    public static final String HOST = "host";
+    public static final String PORT = "port";
+    public static final String CONTEXT_PATH = "contextPath";
+    public static final String HTTPS = "https";
+    public static final String DEFAULT = "defaultBackend";
+    
     private static final long SECONDS_BETWEEN_PARSING = 20;
     
 
@@ -64,7 +67,7 @@ public class BackEndInstancesUtils {
     private boolean savedSinceLastParsing = false;
 
     /**
-     * Function to check weather an instance host, port, path and https is
+     * Function to check weather an instance host, port, context path and https is
      * unique.
      *
      * @param JsonObject
@@ -77,7 +80,7 @@ public class BackEndInstancesUtils {
             // Ensure unique host, port and context paths
             if (backendInformation.getHost().equals(instance.get(HOST).getAsString())
                     && Integer.valueOf(backendInformation.getPort()) == instance.get(PORT).getAsInt()
-                    && backendInformation.getPath().equals(instance.get(PATH).getAsString())
+                    && backendInformation.getContextPath().equals(instance.get(CONTEXT_PATH).getAsString())
                     && backendInformation.isUseSecureHttpBackend() == instance.get(HTTPS).getAsBoolean()) {
                 return true;
             }
@@ -164,7 +167,7 @@ public class BackEndInstancesUtils {
             if (backendInformation.getName().equals(objectToDelete.get(NAME).getAsString())
                     && backendInformation.getHost().equals(objectToDelete.get(HOST).getAsString())
                     && backendInformation.getPort().equals(objectToDelete.get(PORT).getAsString())
-                    && backendInformation.getPath().equals(objectToDelete.get(PATH).getAsString())
+                    && backendInformation.getContextPath().equals(objectToDelete.get(CONTEXT_PATH).getAsString())
                     && backendInformation.isUseSecureHttpBackend() == objectToDelete.get(HTTPS).getAsBoolean()
                     && !backendInformation.isDefaultBackend()) {
                 backEndInformationList.remove(backendInformation);
@@ -197,14 +200,14 @@ public class BackEndInstancesUtils {
      * @param name
      * @param host
      * @param port
-     * @param path
+     * @param contextPath
      * @param def
      */
-    public void setDefaultBackEndInstance(String name, String host, int port, String path, boolean def) {
+    public void setDefaultBackEndInstance(String name, String host, int port, String contextPath, boolean def) {
         getDefaultBackendInformation().setName(name);
         getDefaultBackendInformation().setHost(host);
         getDefaultBackendInformation().setPort(String.valueOf(port));
-        getDefaultBackendInformation().setPath(path);
+        getDefaultBackendInformation().setContextPath(contextPath);
         getDefaultBackendInformation().setUseSecureHttpBackend(false);
         getDefaultBackendInformation().setDefaultBackend(def);
     }

--- a/src/main/java/com/ericsson/ei/frontend/utils/BackEndInstancesUtils.java
+++ b/src/main/java/com/ericsson/ei/frontend/utils/BackEndInstancesUtils.java
@@ -47,8 +47,8 @@ public class BackEndInstancesUtils {
     private static final String PATH = "path";
     private static final String HTTPS = "https";
     private static final long SECONDS_BETWEEN_PARSING = 20;
+    
 
-    @Value("${ei.backendServerName:#{null}}")
     private String defaultBackEndInstanceName;
 
     @Autowired

--- a/src/main/java/com/ericsson/ei/frontend/utils/BackEndInstancesUtils.java
+++ b/src/main/java/com/ericsson/ei/frontend/utils/BackEndInstancesUtils.java
@@ -40,17 +40,16 @@ import lombok.Setter;
 @Component
 public class BackEndInstancesUtils {
 
-	private static final Logger LOG = LoggerFactory.getLogger(BackEndInstancesUtils.class);
-    
-	public static final String NAME = "name";
+    private static final Logger LOG = LoggerFactory.getLogger(BackEndInstancesUtils.class);
+
+    public static final String NAME = "name";
     public static final String HOST = "host";
     public static final String PORT = "port";
     public static final String CONTEXT_PATH = "contextPath";
     public static final String HTTPS = "https";
     public static final String DEFAULT = "defaultBackend";
-    
+
     private static final long SECONDS_BETWEEN_PARSING = 20;
-    
 
     private String defaultBackEndInstanceName;
 
@@ -89,8 +88,8 @@ public class BackEndInstancesUtils {
     }
 
     /**
-     * Returns whether the name is unique, the name is an identifier thus must
-     * be unique.
+     * Returns whether the name is unique, the name is an identifier thus must be
+     * unique.
      *
      * @param JsonObject
      * @return boolean
@@ -109,8 +108,7 @@ public class BackEndInstancesUtils {
     /**
      * Returns the BackEndInformation based on input name.
      *
-     * @param String
-     *            name
+     * @param String name
      * @return backendInformation if exist null if no backendInformation exist
      */
     public BackEndInformation getBackEndInformationByName(String backEndName) {
@@ -142,8 +140,7 @@ public class BackEndInstancesUtils {
     /**
      * Adds a new back end to the backEndInformationList and saves the data.
      *
-     * @param instance
-     *            back end information as JsonObject
+     * @param instance back end information as JsonObject
      */
     public void addNewBackEnd(JsonObject instance) {
         parseBackEndInstances();
@@ -158,8 +155,7 @@ public class BackEndInstancesUtils {
     /**
      * Deletes a back end from the backEndInformationList and saves the new list.
      *
-     * @param objectToDelete
-     *            back end information as JsonObject
+     * @param objectToDelete back end information as JsonObject
      */
     public void deleteBackEnd(JsonObject objectToDelete) {
         parseBackEndInstances();
@@ -245,21 +241,21 @@ public class BackEndInstancesUtils {
 
         currentlyParsing = false;
         savedSinceLastParsing = false;
-        nextTimeToParse  = System.currentTimeMillis() + (SECONDS_BETWEEN_PARSING * 1000);
+        nextTimeToParse = System.currentTimeMillis() + (SECONDS_BETWEEN_PARSING * 1000);
     }
 
     private boolean parsingIsApplicable() {
         /**
-         * If this is a test and test is dependent on parsing to be executed
-         * we want to parse.
+         * If this is a test and test is dependent on parsing to be executed we want to
+         * parse.
          */
         if (isRunningTests) {
             return true;
         }
 
         /**
-         * If parsing is ongoing wait for it to finish, we do not parse again
-         * since it should already be up to date.
+         * If parsing is ongoing wait for it to finish, we do not parse again since it
+         * should already be up to date.
          */
         if (currentlyParsing) {
             long stopTime = System.currentTimeMillis() + 10000;
@@ -273,8 +269,7 @@ public class BackEndInstancesUtils {
         }
 
         /**
-         * If parsing has not been done for a set amount of time,
-         * then we want to parse.
+         * If parsing has not been done for a set amount of time, then we want to parse.
          */
         if (nextTimeToParse <= System.currentTimeMillis()) {
             return true;
@@ -283,7 +278,7 @@ public class BackEndInstancesUtils {
         /**
          * If an update has happened to the file, then we should parse the file.
          */
-        if (savedSinceLastParsing ) {
+        if (savedSinceLastParsing) {
             return true;
         }
 

--- a/src/main/java/com/ericsson/ei/frontend/utils/WebControllerUtils.java
+++ b/src/main/java/com/ericsson/ei/frontend/utils/WebControllerUtils.java
@@ -64,16 +64,16 @@ public class WebControllerUtils {
     public String getFrontEndServiceUrl() {
         String requestedUrl = null;
         String http = "http";
-        String path = "";
+        String contextPath = "";
         if (useSecureHttpFrontend) {
         	http = "https";
         }
 
         if (frontendContextPath != null && !frontendContextPath.isEmpty()) {
-        	path = ("/" + frontendContextPath).replace("//", "/");
+        	contextPath = ("/" + frontendContextPath).replace("//", "/");
         }
 
-        requestedUrl = String.format("%s://%s:%d%s", http, frontendServiceHost, frontendServicePort, path);
+        requestedUrl = String.format("%s://%s:%d%s", http, frontendServiceHost, frontendServicePort, contextPath);
 
         return requestedUrl;
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,7 +4,7 @@ spring.jackson.default-property-inclusion=non_null
 spring.application.name=ei-frontend
   #${project.artifactId}
 
-server.port=8030
+server.port=8080
 #server.ssl.key-store: <keystore.p12>
 #server.ssl.key-store-password: <mypassword>
 #server.ssl.keyStoreType: <PKCS12>
@@ -12,7 +12,7 @@ server.port=8030
 
 ######## EI Front-End
 ei.frontendServiceHost=localhost
-ei.frontendServicePort=8030
+ei.frontendServicePort=8080
 ei.frontendContextPath=
 ei.useSecureHttpFrontend=false
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -18,7 +18,7 @@ ei.useSecureHttpFrontend=false
 
 ######## EI Default Back-Ends
 ei.backendInstancesFilePath=
-ei.backendInstancesListJsonContent=[{ "path": "", "port": "8090", "name": "EI-Backend-1", "host": "localhost", "https": false, "defaultBackend": true}]
+ei.backendInstancesListJsonContent=[{ "contextPath": "", "port": "8090", "name": "EI-Backend-1", "host": "localhost", "https": false, "defaultBackend": true}]
 
 ###### EI Documentation Link Url ##########
 ei.eiffelDocumentationUrls={ "EI Frontend GitHub": "https://github.com/eiffel-community/eiffel-intelligence-frontend",\

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,7 +4,7 @@ spring.jackson.default-property-inclusion=non_null
 spring.application.name=ei-frontend
   #${project.artifactId}
 
-server.port=8080
+server.port=8030
 #server.ssl.key-store: <keystore.p12>
 #server.ssl.key-store-password: <mypassword>
 #server.ssl.keyStoreType: <PKCS12>
@@ -12,17 +12,13 @@ server.port=8080
 
 ######## EI Front-End
 ei.frontendServiceHost=localhost
-ei.frontendServicePort=8080
+ei.frontendServicePort=8030
 ei.frontendContextPath=
 ei.useSecureHttpFrontend=false
 
-######## EI Default Back-End
-ei.backendServerName=default
-ei.backendServerHost=localhost
-ei.backendServerPort=8090
-ei.backendContextPath=
-ei.useSecureHttpBackend=false
+######## EI Default Back-Ends
 ei.backendInstancesFilePath=
+ei.backendInstancesListJsonContent=[{ "path": "", "port": "8090", "name": "EI-Backend-1", "host": "localhost", "https": false, "defaultBackend": true}]
 
 ###### EI Documentation Link Url ##########
 ei.eiffelDocumentationUrls={ "EI Frontend GitHub": "https://github.com/eiffel-community/eiffel-intelligence-frontend",\

--- a/src/main/resources/static/js/add-instances.js
+++ b/src/main/resources/static/js/add-instances.js
@@ -7,7 +7,7 @@ function instanceModel() {
 	    name: ko.observable(""),
 		host: ko.observable(""),
 		port: ko.observable(""),
-		path: ko.observable(""),
+		contextPath: ko.observable(""),
 		https: ko.observable(false)
 	};
 	self.add = function(instance) {

--- a/src/main/resources/static/js/main.js
+++ b/src/main/resources/static/js/main.js
@@ -115,14 +115,14 @@ jQuery(document).ready(function() {
 
     initOneTime();
 
-    function singleInstanceModel(name, host, port, path, https, active) {
+    function singleInstanceModel(name, host, port, contextPath, https, active) {
         this.name = ko.observable(name),
         this.host = ko.observable(host),
         this.port = ko.observable(port),
-        this.path = ko.observable(path),
+        this.contextPath = ko.observable(contextPath),
         this.https = ko.observable(https),
         this.active = ko.observable(active),
-        this.information = name.toUpperCase() + " - " + host + " " + port + "/" + path;
+        this.information = name.toUpperCase() + " - " + host + " " + port + "/" + contextPath;
     }
 
     function viewModel(data) {
@@ -133,7 +133,7 @@ jQuery(document).ready(function() {
         var oldSelectedActive = self.selectedActive;
         for(var i = 0; i < json.length; i++) {
             var obj = json[i];
-            var instance = new singleInstanceModel(obj.name, obj.host, obj.port, obj.path, obj.https, obj.active);
+            var instance = new singleInstanceModel(obj.name, obj.host, obj.port, obj.contextPath, obj.https, obj.active);
             self.instances.push(instance);
             if(obj.active == true){
                 currentName = obj.name;

--- a/src/main/resources/static/js/switch-instances.js
+++ b/src/main/resources/static/js/switch-instances.js
@@ -2,11 +2,11 @@ jQuery(document).ready(function() {
 var frontendServiceUrl = $('#frontendServiceUrl').text();
 var frontendServiceBackEndPath = "/backend";
 var sendbtn = document.getElementById('switcher').disabled = true;
-function singleInstanceModel(name, host, port, path, https, active) {
+function singleInstanceModel(name, host, port, contextPath, https, active) {
     this.name = ko.observable(name),
     this.host = ko.observable(host),
     this.port = ko.observable(port),
-    this.path = ko.observable(path),
+    this.contextPath = ko.observable(contextPath),
     this.https = ko.observable(https),
     this.active = ko.observable(active)
 }
@@ -17,7 +17,7 @@ function multipleInstancesModel(data) {
     var json = JSON.parse(ko.toJSON(data));
     for(var i = 0; i < json.length; i++) {
         var obj = json[i];
-        var instance = new singleInstanceModel(obj.name, obj.host, obj.port, obj.path, obj.https, obj.active);
+        var instance = new singleInstanceModel(obj.name, obj.host, obj.port, obj.contextPath, obj.https, obj.active);
         self.instances.push(instance);
     }
     self.checked = function(){

--- a/src/main/resources/templates/add-instances.html
+++ b/src/main/resources/templates/add-instances.html
@@ -31,7 +31,7 @@
                 <div class="form-group">
                     <label>Context path</label>
                     <input class="form-control" id="backEndPath" type="text" placeholder="Enter context path"
-                           data-bind="textInput: $root.instance.path" title="Path for backend instance should be like:'eiffel' or 'eibackend'"/>
+                           data-bind="textInput: $root.instance.contextPath" title="Context path for backend instance should be like:'eiffel' or 'eibackend'"/>
                 </div>
                 <div class="form-group">
                     <div class="form-check">

--- a/src/main/resources/templates/switch-backend.html
+++ b/src/main/resources/templates/switch-backend.html
@@ -20,7 +20,7 @@
                     <th>Name</th>
                     <th>Host</th>
                     <th>Port</th>
-                    <th>Path</th>
+                    <th>Context Path</th>
                     <th>Secured</th>
                     <th></th>
                 </tr>
@@ -32,7 +32,7 @@
                     <td data-bind="text: name, attr: { id: 'BackendInstance' + $index() + 'Name'}"></td>
                     <td data-bind="text: host"></td>
                     <td data-bind="text: port"></td>
-                    <td data-bind="text: path"></td>
+                    <td data-bind="text: contextPath"></td>
                     <td class="text-center"><input type="checkbox" disabled="disabled" data-bind="checked: https"/></td>
                     <td class="text-center"><a href="#" data-bind="click: $parent.removeInstance, attr: { id: 'removeBtn' + $index()}">Remove</a></td>
                 </tr>

--- a/src/test/java/com/ericsson/ei/frontend/BackEndInformationTest.java
+++ b/src/test/java/com/ericsson/ei/frontend/BackEndInformationTest.java
@@ -35,7 +35,7 @@ public class BackEndInformationTest {
     private static final String NAME = "name";
     private static final String HOST = "host";
     private static final String PORT = "port";
-    private static final String PATH = "path";
+    private static final String CONTEXT_PATH = "contextPath";
     private static final String HTTPS = "https";
     private static final String DEFAULT = "defaultBackend";
 
@@ -58,7 +58,7 @@ public class BackEndInformationTest {
         instance.addProperty(NAME, BACK_END_NAME);
         instance.addProperty(HOST, BACK_END_HOST);
         instance.addProperty(PORT, Integer.valueOf(BACK_END_PORT));
-        instance.addProperty(PATH, "");
+        instance.addProperty(CONTEXT_PATH, "");
         instance.addProperty(HTTPS, true);
         instance.addProperty(DEFAULT, false);
 
@@ -79,7 +79,7 @@ public class BackEndInformationTest {
         backEndInformation.setUseSecureHttpBackend(false);
         assertEquals(urlWithHttp, backEndInformation.getUrlAsString());
 
-        backEndInformation.setPath("/path/");
+        backEndInformation.setContextPath("/path/");
         LOG.error("backEndInformation = " + backEndInformation.getUrlAsString());
         assertEquals(urlWithHttpwothPath, backEndInformation.getUrlAsString());
 

--- a/src/test/java/com/ericsson/ei/frontend/BackendInformationControllerUtilsTest.java
+++ b/src/test/java/com/ericsson/ei/frontend/BackendInformationControllerUtilsTest.java
@@ -126,7 +126,7 @@ public class BackendInformationControllerUtilsTest {
         when(mockedSession.getAttribute("backEndInstanceName")).thenReturn(null);
         when(backEndInstancesUtils.getBackEndsAsJsonArray()).thenReturn(new JsonArray());
         expectedResponse = createExpectedResponse(
-                "[{\"name\":\"Unable to load instances\",\"host\":\"NO HOST\",\"port\":\"NO PORT\",\"path\":\"/\"}]",
+                "[{\"name\":\"Unable to load instances\",\"host\":\"NO HOST\",\"port\":\"NO PORT\",\"contextPath\":\"/\"}]",
                 HttpStatus.OK);
         response = backendInfoContrUtils.handleRequestForInstances(mockedRequest);
         assertEquals(expectedResponse, response);

--- a/src/test/java/com/ericsson/ei/frontend/BackendInstancesUtilsTest.java
+++ b/src/test/java/com/ericsson/ei/frontend/BackendInstancesUtilsTest.java
@@ -71,7 +71,7 @@ public class BackendInstancesUtilsTest {
         JsonObject newInstance = instance.getAsJsonObject();
         newInstance.addProperty("host", "newHost");
         newInstance.addProperty("port", newInstance.get("port").getAsInt() + 1);
-        newInstance.addProperty("path", "newPath");
+        newInstance.addProperty("contextPath", "newPath");
         result = utils.checkIfInstanceAlreadyExist(newInstance);
 
         assertEquals("Instance should not exist: '" + result + "'.", false, result);
@@ -87,7 +87,7 @@ public class BackendInstancesUtilsTest {
         newInstance = instance.getAsJsonObject();
         newInstance.addProperty("host", "newHost");
         newInstance.addProperty("port", newInstance.get("port").getAsInt() + 1);
-        newInstance.addProperty("path", "newPath");
+        newInstance.addProperty("contextPath", "newPath");
 
         result = utils.checkIfInstanceNameAlreadyExist(newInstance);
         assertEquals("Instance name should already exist: '" + result + "'.", true, result);

--- a/src/test/java/com/ericsson/ei/frontend/EIRequestControllerTest.java
+++ b/src/test/java/com/ericsson/ei/frontend/EIRequestControllerTest.java
@@ -87,7 +87,7 @@ public class EIRequestControllerTest {
         backEndInformation.setName("test");
         backEndInformation.setHost("localhost");
         backEndInformation.setPort(String.valueOf(mockServerRule.getPort()));
-        backEndInformation.setPath("");
+        backEndInformation.setContextPath("");
         backEndInformation.setUseSecureHttpBackend(false);
         backEndInformation.setDefaultBackend(true);
     }

--- a/src/test/java/com/ericsson/ei/frontend/WebControllerUtilsTest.java
+++ b/src/test/java/com/ericsson/ei/frontend/WebControllerUtilsTest.java
@@ -29,13 +29,13 @@ import com.ericsson.ei.frontend.utils.WebControllerUtils;
 public class WebControllerUtilsTest {
 	private static final String HOST = "testHost";
 	private static final int PORT = 12345;
-	private static final String PATH = "/path";
+	private static final String CONTEXT_PATH = "/path";
     private WebControllerUtils controllerUtils;
 
     @Test
     public void testGetFrontEndServiceUrl() throws Exception {
-    	String expectedUrl = String.format("http://%s:%s%s", HOST, PORT, PATH);
-    	controllerUtils = new WebControllerUtils(HOST, PORT, PATH, false, null, null);
+    	String expectedUrl = String.format("http://%s:%s%s", HOST, PORT, CONTEXT_PATH);
+    	controllerUtils = new WebControllerUtils(HOST, PORT, CONTEXT_PATH, false, null, null);
     	assertEquals(expectedUrl, controllerUtils.getFrontEndServiceUrl());
     }
 

--- a/src/test/resources/backendInstances/backendInstance.json
+++ b/src/test/resources/backendInstances/backendInstance.json
@@ -2,7 +2,7 @@
     "name": "someName",
     "host": "someHost",
     "port": 9888,
-    "path": "somePath",
+    "contextPath": "somePath",
     "https": false,
     "defaultBackend": false
 }

--- a/src/test/resources/backendInstances/backendInstances.json
+++ b/src/test/resources/backendInstances/backendInstances.json
@@ -3,7 +3,7 @@
         "name": "someName",
         "host": "someHost",
         "port": 9888,
-        "path": "somePath",
+        "contextPath": "somePath",
         "https": false,
         "defaultBackend": false
     },
@@ -11,7 +11,7 @@
         "name": "otherName",
         "host": "otherHost",
         "port": 9998,
-        "path": "otherPath",
+        "contextPath": "otherPath",
         "https": false,
         "defaultBackend": true
     }

--- a/src/test/resources/backendInstances/expectedNotDefaultResponseInstances.json
+++ b/src/test/resources/backendInstances/expectedNotDefaultResponseInstances.json
@@ -3,7 +3,7 @@
         "name": "someName",
         "host": "someHost",
         "port": 9888,
-        "path": "somePath",
+        "contextPath": "somePath",
         "https": false,
         "defaultBackend": false,
         "active": true
@@ -12,7 +12,7 @@
         "name": "otherName",
         "host": "otherHost",
         "port": 9998,
-        "path": "otherPath",
+        "contextPath": "otherPath",
         "https": false,
         "defaultBackend": true,
         "active": false

--- a/src/test/resources/backendInstances/expectedResponseInstances.json
+++ b/src/test/resources/backendInstances/expectedResponseInstances.json
@@ -3,7 +3,7 @@
         "name": "someName",
         "host": "someHost",
         "port": 9888,
-        "path": "somePath",
+        "contextPath": "somePath",
         "https": false,
         "defaultBackend": false,
         "active": false
@@ -12,7 +12,7 @@
         "name": "otherName",
         "host": "otherHost",
         "port": 9998,
-        "path": "otherPath",
+        "contextPath": "otherPath",
         "https": false,
         "defaultBackend": true,
         "active": true

--- a/src/test/resources/backendInstances/fileToParseInstances.json
+++ b/src/test/resources/backendInstances/fileToParseInstances.json
@@ -3,7 +3,7 @@
         "name": "firstName",
         "host": "firstHost",
         "port": 7676,
-        "path": "firstPath",
+        "contextPath": "firstPath",
         "https": false,
         "active": false
     },
@@ -11,7 +11,7 @@
         "name": "secondName",
         "host": "secondHost",
         "port": 6767,
-        "path": "secondPath",
+        "contextPath": "secondPath",
         "https": false,
         "active": true
     }


### PR DESCRIPTION

### Applicable Issues
User is not able to configure EI-Backend instances list from command line.

### Description of the Change
Adding an application property for handling EI Backend instances which is configurable from command line and adapt code to these new setting changes.

Example of command line execution:
java -jar target/eiffel-intelligence-frontend-0.0.17.war --ei.backendInstancesListJsonContent='[  { "path": "",   "port": "8031",  "name": "EI-Backend-1", "host": "localhost", "https": false, "defaultBackend": true }]'


java -jar target/eiffel-intelligence-frontend-0.0.17.war --ei.backendInstancesListJsonContent='[{ "path": "", "port": "8070",  "name": "EI-Backend-1", "host": "localhost", "https": false, "defaultBackend": false },{ "path": "",   "port": "8076",  "name": "EI-Backend-2", "host": "localhost", "https": false, "defaultBackend": true }]'


java -jar target/eiffel-intelligence-frontend-0.0.17.war --ei.backendInstancesListJsonContent='[{ "path": "", "port": "8070",  "name": "EI-Backend-1", "host": "localhost", "https": false, "defaultBackend": false },{ "path": "",   "port": "8076",  "name": "EI-Backend-2", "host": "localhost", "https": false, "defaultBackend": true }]' --ei.backendInstancesFilePath=/tmp/eitest4.json

It is also possible to set these properties directly in application.porperies file.