### PR TITLE
Add usage information in test rules

### DIFF
--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -193,3 +193,26 @@ input:checked + .slider:before {
         width: 100%;
     }
 }
+
+button.rules_info {
+  text-align: center;
+  max-height: auto;
+  max-width: auto;
+  margin: 0px;
+  padding: 0px;
+  background: white;
+  border: none;
+}
+
+button.rules_info:active {
+    outline: none;
+}
+
+button.rules_info:focus {
+    outline:0;
+    outline:none;
+}
+
+#infoContent{
+   font: 16px "Calibri";
+}

--- a/src/main/resources/static/js/testrules.js
+++ b/src/main/resources/static/js/testrules.js
@@ -2,25 +2,7 @@
 var frontendServiceUrl;
 var i = 0;
 var isReplacing = true;
-var ruleTemplate = {
-  "TemplateName" : "",
-  "Type" : "",
-  "TypeRule" : "",
-  "IdRule" : "",
-  "StartEvent" : "",
-  "IdentifyRules" : "",
-  "MatchIdRules" : {},
-  "ExtractionRules" : "",
-  "DownstreamIdentifyRules" : "",
-  "DownstreamMergeRules" : "",
-  "DownstreamExtractionRules" : "",
-  "ArrayMergeOptions" : "",
-  "HistoryIdentifyRules" : "",
-  "HistoryExtractionRules" : "",
-  "HistoryPathRules" : "",
-  "ProcessRules" : null,
-  "ProcessFunction" : null
-};
+
 jQuery(document).ready(
     function() {
 
@@ -167,6 +149,14 @@ jQuery(document).ready(
         }
         return self;
       }
+
+      //Create information modal
+      $(".container").on("click", "button.rules_info", function(event) {
+        event.stopPropagation();
+        event.preventDefault();
+        $('#infoContent').text(test_rule_info);
+        $('#infoModal').modal('show');
+      });
 
       var vm = new AppViewModel();
       ko.applyBindings(vm, $("#submitButton")[0]);

--- a/src/main/resources/static/resources/testRules_constants.js
+++ b/src/main/resources/static/resources/testRules_constants.js
@@ -1,0 +1,42 @@
+// Short usage description of test rules
+var test_rule_info = '1. Load buttons are for loading rules/events from extern files.\n' +
+                    '    It is possible to choose if you want to append or replace\n' +
+                    '    aready writen rules/events in the text areas.\n'+
+                    '      * Upload rules/events must be in json list, ex. [{},{}].\n' +
+                    '\n2. By clicking on "Get Template" buttons you will download rules\n' +
+                    '    respective events template. Rule´s template contains 3 rules\n' +
+                    '    and event´s template contains 3 events.\n'+
+                    '\n3. Add buttons are for adding new rules/events. When you click\n' +
+                    '    on one of them, a new text area will show up.\n'+
+                    '      * There can be only one JSON object per text area. One\n' +
+                    '          rule/event per text area.\n' +
+                    '\n4. Download buttons are for downloading edited rules/events.\n'+
+                    '\n5. "Clear All" buttons remove all rules respective events. It\n' +
+                    '    is possible to remove single rule/event by clicking on trash\n' +
+                    '    button next to specific text area.\n'+
+                    '\n6. Clicking on "Find Aggregated Object" button will start\n' +
+                    '    the aggregation process. If rules and events are correct,\n' +
+                    '    a pop up window with aggregated object will show up on\n' +
+                    '    the screen.\n' +
+                    '\nFor more information visit:';
+
+// Default template for rules
+var ruleTemplate = {
+  "TemplateName" : "",
+  "Type" : "",
+  "TypeRule" : "",
+  "IdRule" : "",
+  "StartEvent" : "",
+  "IdentifyRules" : "",
+  "MatchIdRules" : {},
+  "ExtractionRules" : "",
+  "DownstreamIdentifyRules" : "",
+  "DownstreamMergeRules" : "",
+  "DownstreamExtractionRules" : "",
+  "ArrayMergeOptions" : "",
+  "HistoryIdentifyRules" : "",
+  "HistoryExtractionRules" : "",
+  "HistoryPathRules" : "",
+  "ProcessRules" : null,
+  "ProcessFunction" : null
+};

--- a/src/main/resources/static/resources/testRules_constants.js
+++ b/src/main/resources/static/resources/testRules_constants.js
@@ -2,21 +2,25 @@
 var test_rule_info = '1. Load buttons are for loading rules/events from extern files.\n' +
                     '    It is possible to choose if you want to append or replace\n' +
                     '    aready writen rules/events in the text areas.\n'+
-                    '      * Upload rules/events must be in json list, ex. [{},{}].\n' +
+                    '      * The file content should be formatted as JSON objects in\n' +
+                    '         a JSON list, ex. [{Object1}, {Object2}].\n' +
                     '\n2. By clicking on "Get Template" buttons you will download rules\n' +
                     '    respective events template. Rule´s template contains 3 rules\n' +
                     '    and event´s template contains 3 events.\n'+
                     '\n3. Add buttons are for adding new rules/events. When you click\n' +
                     '    on one of them, a new text area will show up.\n'+
                     '      * There can be only one JSON object per text area. One\n' +
-                    '          rule/event per text area.\n' +
+                    '         rule/event per text area.\n' +
                     '\n4. Download buttons are for downloading edited rules/events.\n'+
+                    '      * This enables you to edit rules/events locally and\n' +
+                    '         then upload them using above mentioned load rules/\n' +
+                    '         events buttons.\n' +
                     '\n5. "Clear All" buttons remove all rules respective events. It\n' +
                     '    is possible to remove single rule/event by clicking on trash\n' +
-                    '    button next to specific text area.\n'+
+                    '    can button next to specific text area.\n'+
                     '\n6. Clicking on "Find Aggregated Object" button will start\n' +
                     '    the aggregation process. If rules and events are correct,\n' +
-                    '    a pop up window with aggregated object will show up on\n' +
+                    '    a pop up window with the aggregated object will show up on\n' +
                     '    the screen.\n' +
                     '\nFor more information visit:';
 

--- a/src/main/resources/static/resources/testRules_constants.js
+++ b/src/main/resources/static/resources/testRules_constants.js
@@ -1,7 +1,7 @@
 // Short usage description of test rules
-var test_rule_info = '1. Load buttons are for loading rules/events from extern files.\n' +
+var test_rule_info = '1. Load buttons are for loading rules/events from external files.\n' +
                     '    It is possible to choose if you want to append or replace\n' +
-                    '    aready writen rules/events in the text areas.\n'+
+                    '    aready written rules/events in the text areas.\n'+
                     '      * The file content should be formatted as JSON objects in\n' +
                     '         a JSON list, ex. [{Object1}, {Object2}].\n' +
                     '\n2. By clicking on "Get Template" buttons you will download rules\n' +

--- a/src/main/resources/templates/testRules.html
+++ b/src/main/resources/templates/testRules.html
@@ -9,6 +9,7 @@
     <meta name="author" content="" />
     <script type="text/javascript" src="js/testrules.js"></script>
     <script type="text/javascript" src="js/downloadFile.js"></script>
+    <script type="text/javascript" src="resources/testRules_constants.js"></script>
 </head>
 
 <body>
@@ -37,9 +38,6 @@
                            Clear All Rules
                            <i class="fa fa-fw  fa-trash"></i>
                        </button>
-	                </div>
-                    <div>
-	                    <img class="cursor-pointer" id="uploadRulesInfo" alt="Upload Information" src="assets/images/information.png" data-toggle="tooltip" data-placement="top" title="Upload rules must be in a json list, Ex: [{},{}]"/>
 	                </div>
                 </div>
                 <div class="col-12 pt-2">
@@ -83,9 +81,6 @@
                            <i class="fa fa-fw  fa-trash"></i>
                        </button>
                     </div>
-                    <div>
-                        <img class="cursor-pointer" id="uploadEventsInfo" alt="Upload Information" src="assets/images/information.png" data-toggle="tooltip" data-placement="top" title="Upload events must be in a json list, Ex: [{},{}]"/>
-                    </div>
                 </div>
                 <div class="col-12 pt-2">
                     <h3>Events</h3>
@@ -118,6 +113,9 @@
                 </div>
                 <div class="col-4 text-center">
                     <button class="btn btn-success find_aggregated_object white-space-normal" data-bind="click : $root.submit.bind($data)">Find Aggregated Object</button>
+                    <button class="rules_info">
+                        <img src="assets/images/information.png"/>
+                    </button>
                 </div>
                 <div class="col-4">
                     <button class="btn btn-success download_events white-space-normal float-right">
@@ -152,6 +150,27 @@
 	      </div>
 	      <div class="modal-body modal-height-fit">
 	        <p id="aggregatedObjectContent" class="pre"></p>
+	      </div>
+	      <div class="modal-footer">
+	        <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+	      </div>
+	    </div>
+	  </div>
+	</div>
+	<div id="infoModal" class="modal fade" role="dialog">
+	  <div class="modal-dialog" role="document">
+	    <div class="modal-content">
+	      <div class="modal-header">
+	        <h5 class="modal-title">Usage Information</h5>
+	        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+	          <span aria-hidden="true">&times;</span>
+	        </button>
+	      </div>
+	      <div class="modal-body modal-height-fit">
+	        <p id="infoContent" class="pre"></p>
+	        <div style="text-align: center">
+	           <a href="https://github.com/eiffel-community/eiffel-intelligence/blob/master/wiki/TestRulesUserGuide.md" style="text-decoration: none;">Test Rules User Guide</a>
+	        </div>
 	      </div>
 	      <div class="modal-footer">
 	        <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>

--- a/src/main/resources/templates/testRules.html
+++ b/src/main/resources/templates/testRules.html
@@ -168,8 +168,8 @@
 	      </div>
 	      <div class="modal-body modal-height-fit">
 	        <p id="infoContent" class="pre"></p>
-	        <div style="text-align: center">
-	           <a href="https://github.com/eiffel-community/eiffel-intelligence/blob/master/wiki/TestRulesUserGuide.md" style="text-decoration: none;">Test Rules User Guide</a>
+	        <div class="text-center">
+	           <a href="https://github.com/eiffel-community/eiffel-intelligence/blob/master/wiki/TestRulesUserGuide.md" target="_blank" rel="noopener noreferrer" style="text-decoration: none;">Test Rules User Guide</a>
 	        </div>
 	      </div>
 	      <div class="modal-footer">


### PR DESCRIPTION
### Applicable Issues
Not enough information about usage on test rules page.

### Description of the Change
Removed tooltips. Instead I added  a button that opens a modal that contains more information and a link to test rules documentation on github.

### Alternate Designs

### Benefits
More useful information in one place. User does not need to open documentation on github to understand how test rules interface works.

### Possible Drawbacks
None

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Jakub Binieda, jakub.binieda@ericsson.com
