### PR TITLE
Hide remove button of default backend instance

### DIFF
--- a/src/main/resources/static/js/switch-instances.js
+++ b/src/main/resources/static/js/switch-instances.js
@@ -2,13 +2,14 @@ jQuery(document).ready(function() {
 var frontendServiceUrl = $('#frontendServiceUrl').text();
 var frontendServiceBackEndPath = "/backend";
 var sendbtn = document.getElementById('switcher').disabled = true;
-function singleInstanceModel(name, host, port, path, https, active) {
+function singleInstanceModel(name, host, port, path, https, active, defaultBackend) {
     this.name = ko.observable(name),
     this.host = ko.observable(host),
     this.port = ko.observable(port),
     this.path = ko.observable(path),
     this.https = ko.observable(https),
     this.active = ko.observable(active)
+    this.defaultBackend = ko.observable(defaultBackend)
 }
 function multipleInstancesModel(data) {
     var self = this;
@@ -17,7 +18,7 @@ function multipleInstancesModel(data) {
     var json = JSON.parse(ko.toJSON(data));
     for(var i = 0; i < json.length; i++) {
         var obj = json[i];
-        var instance = new singleInstanceModel(obj.name, obj.host, obj.port, obj.path, obj.https, obj.active);
+        var instance = new singleInstanceModel(obj.name, obj.host, obj.port, obj.path, obj.https, obj.active, obj.defaultBackend);
         self.instances.push(instance);
     }
     self.checked = function(){

--- a/src/main/resources/templates/switch-backend.html
+++ b/src/main/resources/templates/switch-backend.html
@@ -34,7 +34,8 @@
                     <td data-bind="text: port"></td>
                     <td data-bind="text: path"></td>
                     <td class="text-center"><input type="checkbox" disabled="disabled" data-bind="checked: https"/></td>
-                    <td class="text-center"><a href="#" data-bind="click: $parent.removeInstance, attr: { id: 'removeBtn' + $index()}">Remove</a></td>
+                    <td class="text-center"><a href="#" data-bind="click: $parent.removeInstance, attr: { id: 'removeBtn' + $index()},
+                        style:{visibility:($root.instances()[$index()].defaultBackend().valueOf() === true) ? 'hidden' : 'visible'}">Remove</a></td>
                 </tr>
                 </tbody>
             </table>


### PR DESCRIPTION
### Applicable Issues
The default back end cannot be removed from the web gui. But the "Remove" button is still present for the default back end in the switch back end page. This may be confusing and the button should be removed in case the back end is marked as defaultBackend.

### Description of the Change
I get the information from json object, about if the backend instance is default. And hide remove button depending on if it is true or not.

### Alternate Designs
None

### Benefits
None

### Possible Drawbacks
None

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Jakub Binieda, jakub.binieda@ericsson.com
