### PR TITLE
Fix login blocks and username on backend status

### DIFF
--- a/src/main/resources/static/js/common.js
+++ b/src/main/resources/static/js/common.js
@@ -1,0 +1,62 @@
+var frontendServiceUrl = $('#frontendServiceUrl').text();
+
+function doIfUserLoggedIn(user) {
+    localStorage.removeItem("currentUser");
+    localStorage.setItem("currentUser", user);
+    $("#ldapUserName").show();
+    $("#ldapUserName").text(user);
+    $("#loginBlock").hide();
+    $("#logoutBlock").show();
+    $(".show_if_authorized").show();
+}
+
+function doIfUserLoggedOut() {
+    localStorage.removeItem("currentUser");
+    $("#ldapUserName").show();
+    $("#ldapUserName").text("Guest");
+    $("#loginBlock").show();
+    $("#logoutBlock").hide();
+    $(".show_if_authorized").hide();
+    localStorage.setItem('errorsStore', []);
+}
+
+function doIfSecurityOff() {
+    $("#ldapUserName").text("");
+    $("#loginBlock").hide();
+    $("#logoutBlock").hide();
+}
+
+function checkBackendSecured() {
+    $.ajax({
+        url: frontendServiceUrl + "/auth",
+        type: "GET",
+        contentType: "application/string; charset=utf-8",
+        error: function (data) {
+            doIfSecurityOff();
+        },
+        success: function (data) {
+            var isSecured = JSON.parse(ko.toJSON(data)).security;
+            if (isSecured == true) {
+                checkLoggedInUser();
+            } else {
+                doIfSecurityOff();
+            }
+        }
+    });
+}
+
+function checkLoggedInUser() {
+    $.ajax({
+        url : frontendServiceUrl + "/auth/login",
+        type : "GET",
+        contentType : 'application/string; charset=utf-8',
+        cache: false,
+        error : function (request, textStatus, errorThrown) {
+            doIfUserLoggedOut();
+        },
+        success : function (responseData, textStatus) {
+            var user = JSON.parse(ko.toJSON(responseData)).user;
+            doIfUserLoggedIn(user);
+        }
+    });
+}

--- a/src/main/resources/static/js/login.js
+++ b/src/main/resources/static/js/login.js
@@ -63,14 +63,6 @@ jQuery(document).ready(function() {
 		});
 	}
 
-    function doIfUserLoggedIn(name) {
-        localStorage.removeItem("currentUser");
-        localStorage.setItem("currentUser", name);
-        $("#ldapUserName").text(name);
-        $("#loginBlock").hide();
-        $("#logoutBlock").show();
-    }
-
 	var observableObject = $("#viewModelDOMObject")[0];
 	ko.cleanNode(observableObject);
 	var model = new loginModel();

--- a/src/main/resources/static/js/main.js
+++ b/src/main/resources/static/js/main.js
@@ -72,23 +72,6 @@ jQuery(document).ready(function() {
         });
     });
 
-    function doIfUserLoggedIn(currentUser) {
-        localStorage.removeItem("currentUser");
-        localStorage.setItem("currentUser", currentUser);
-        $("#ldapUserName").text(currentUser);
-        $("#logoutBlock").show();
-        $(".show_if_authorized").show();
-    }
-
-    function doIfUserLoggedOut() {
-        localStorage.removeItem("currentUser");
-        $("#ldapUserName").text("Guest");
-        $("#loginBlock").show();
-        $("#logoutBlock").hide();
-        $(".show_if_authorized").hide();
-        localStorage.setItem('errorsStore', []);
-    }
-
     function updateBackEndInstanceList() {
         $.ajax({
             url: frontendServiceUrl + frontendServiceBackEndPath,
@@ -102,37 +85,6 @@ jQuery(document).ready(function() {
                 var observableObject = $("#selectInstances")[0];
                 ko.cleanNode(observableObject);
                 ko.applyBindings(new viewModel(responseData),observableObject);
-            }
-        });
-    }
-
-    function checkBackendSecured() {
-        $.ajax({
-            url: frontendServiceUrl + "/auth",
-            type: "GET",
-            contentType: "application/string; charset=utf-8",
-            error: function (data) {},
-            success: function (data) {
-                var isSecured = JSON.parse(ko.toJSON(data)).security;
-                if (isSecured == true) {
-                    checkLoggedInUser();
-                }
-            }
-        });
-    }
-
-    function checkLoggedInUser() {
-        $.ajax({
-            url : frontendServiceUrl + "/auth/login",
-            type : "GET",
-            contentType : 'application/string; charset=utf-8',
-            cache: false,
-            error : function (request, textStatus, errorThrown) {
-                doIfUserLoggedOut();
-            },
-            success : function (responseData, textStatus) {
-                var user = JSON.parse(ko.toJSON(responseData)).user;
-                doIfUserLoggedIn(user);
             }
         });
     }

--- a/src/main/resources/static/js/subscription.js
+++ b/src/main/resources/static/js/subscription.js
@@ -61,11 +61,15 @@ jQuery(document).ready(function () {
                     EIConnBtn.style.background = green;
                     backendStatus = true;
                 } else {
+                    doIfSecurityOff();
                     EIConnBtn.style.background = red;
                     backendStatus = false;
                 }
             },
             success: function (data, textStatus) {
+                if(backendStatus == false) {
+                    checkBackendSecured();
+                }
                 EIConnBtn.style.background = green;
                 backendStatus = true;
             },
@@ -75,15 +79,6 @@ jQuery(document).ready(function () {
         });
     }
     checkBackendStatus();
-
-    function doIfUserLoggedOut() {
-        localStorage.removeItem("currentUser");
-        $("#ldapUserName").text("Guest");
-        $("#loginBlock").show();
-        $("#logoutBlock").hide();
-        $(".show_if_authorized").hide();
-        localStorage.setItem('errorsStore', []);
-    }
 
     function loadSubButtons() {
         $("#loadingAnimation").hide();

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -88,7 +88,7 @@
       </ul>
       <ul class="navbar-nav ml-auto">
         <li class="nav-item dropdown">
-          <a class="nav-link dropdown-toggle mr-lg-2" id="alertsDropdown">
+          <a class="nav-link dropdown-toggle" id="alertsDropdown">
             <i class="fa fa-fw fa-bell"></i>
             <span class="d-lg-none">Alerts
               <span class="badge badge-pill badge-warning">6 New</span>
@@ -169,5 +169,6 @@
   <script type="text/javascript" src="assets/navigo/7.1.2/navigo.min.js"></script>
   <script type="text/javascript" src="js/main.js"></script>
   <script type="text/javascript" src="js/errorMessages.js"></script>
+  <script type="text/javascript" src="js/common.js"></script>
 </body>
 </html>

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -10,9 +10,8 @@
 </head>
 
 <body class="bg-dark">
-<div class="hidden" style="display: none" id="frontendServiceUrl" th:text="${frontendServiceUrl}"></div>
-<div class="container pull-left">
-    <div class="card card-login mx-auto mt-5">
+<div class="d-flex justify-content-center ml-3 mr-3">
+    <div class="card card-standard">
         <div class="card-header">Login</div>
         <div class="card-body">
             <form id="viewModelDOMObject" autocomplete="on">


### PR DESCRIPTION
### Applicable Issues
Login related blocks and username was still shown even when backend status was red and when it got back up again the login blocks and username was not updated. Might have been introduced in my previous commit #104 

### Description of the Change
- Login and security checks have been moved into a common js file
- Login blocks and username should be hidden now when backend goes down
- Login blocks and username should reappear now when backend goes up

### Alternate Designs

### Benefits

### Possible Drawbacks

### Sign-off
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Christoffer Cortes Sjöwall, christoffer.cortes.sjowall@ericsson.com
