### PR TITLE
Alert drop down margin fix

### DIFF
--- a/src/main/resources/static/css/errMsg.css
+++ b/src/main/resources/static/css/errMsg.css
@@ -1,6 +1,0 @@
-.dropdown-menu {
-    max-height: 400px;
-    overflow-y: auto;
-    margin-left: -300px;
-}
-

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -191,7 +191,6 @@ input:checked + .slider:before {
 .slider.round:before {
     border-radius: 50%;
 }
-
 /* Safari */
 @-webkit-keyframes spin {
     0% { -webkit-transform: rotate(0deg); }
@@ -201,20 +200,6 @@ input:checked + .slider:before {
     0% { transform: rotate(0deg); }
     100% { transform: rotate(360deg); }
 }
-
-@media (max-width: 576px) {
-	body {
-        padding-top: 80px;
-    }
-    .container {
-        max-width: 480px;
-    }
-    .split {
-        max-width: 100%;
-        width: 100%;
-    }
-}
-
 button.rules_info {
   text-align: center;
   max-height: auto;
@@ -224,16 +209,38 @@ button.rules_info {
   background: white;
   border: none;
 }
-
 button.rules_info:active {
     outline: none;
 }
-
 button.rules_info:focus {
     outline:0;
     outline:none;
 }
-
 #infoContent{
    font: 16px "Calibri";
+}
+.dropdown-menu {
+    max-height: 400px;
+    overflow-y: auto;
+    margin-left: -50px;
+}
+@media (max-width: 992px) {
+    .dropdown-menu {
+        margin-left: 0px;
+    }
+}
+@media (max-width: 576px) {
+    body {
+        padding-top: 80px;
+    }
+    .container {
+        max-width: 480px;
+    }
+    .split {
+        max-width: 100%;
+        width: 100%;
+    }
+    .dropdown-menu {
+	    margin-left: 0px;
+	}
 }

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -88,7 +88,7 @@
       </ul>
       <ul class="navbar-nav ml-auto">
         <li class="nav-item dropdown">
-          <a class="nav-link dropdown-toggle mr-lg-2" id="alertsDropdown">
+          <a class="nav-link dropdown-toggle" id="alertsDropdown">
             <i class="fa fa-fw fa-bell"></i>
             <span class="d-lg-none">Alerts
               <span class="badge badge-pill badge-warning">6 New</span>


### PR DESCRIPTION
### Applicable Issues
Alert drop down was misaligned and in smaller screens the error messages would be cut off.

### Description of the Change
- Drop down CSS has been moved into styles.css
- Margin has been fixed in larger and smaller screens

### Alternate Designs

### Benefits

### Possible Drawbacks

### Sign-off
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Christoffer Cortes Sjöwall, christoffer.cortes.sjowall@ericsson.com
