### PR TITLE
Added Dockerfile for build docker image based on local source code ch…

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,4 @@ Visit [Eiffel Community](https://eiffel-community.github.io) to get started and 
 1. [**Test Rules User Guide**](./wiki/markdown/Test-Rules.md)
 1. [**Front-end With CURL**](./wiki/markdown/Front-end_with_curl.md)
     - [**Examples, using CURL through EI Front-End**](./wiki/markdown/Front-end_with_curl.md#Curl-Examples)
+1. [**Docker**](./wiki/markdown/docker.md)

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -1,0 +1,13 @@
+FROM fabric8/java-jboss-openjdk8-jdk:1.2
+MAINTAINER Eiffel-Community
+USER root
+ENV JAVA_APP_DIR=/deployments
+ENV JAVA_APP_JAR=eiffel-intelligence-frontend.war
+EXPOSE 8092 8778 9779
+
+# Create image with existing war file. User need to execute 'mvn package -DskipTest' before 'docker build'
+COPY ./target/eiffel-intelligence-frontend-*.war /deployments/eiffel-intelligence-frontend.war
+
+CMD /deployments/run-java.sh
+
+

--- a/wiki/markdown/docker.md
+++ b/wiki/markdown/docker.md
@@ -1,7 +1,7 @@
 # Docker
 
-In Eiffel-Intelligence frontend source code a Dockerfile is provided which helps the developer or user to build the local Eiffel-Intellegence frontend source code changes to a Docker image.
-With the Docker image user can tryout the Eiffel-Intelligence frontend on a Docker Host or in a Kubernetes cluster.
+In Eiffel-Intelligence frontend source code a Dockerfile is provided which helps the developer or user to build the local Eiffel-Intellegence frontend source code repository changes to a Docker image.
+With the Docker image user can try-out the Eiffel-Intelligence frontend on a Docker Host or in a Kubernetes cluster.
 
 ## Requirements
 - Docker 
@@ -19,6 +19,8 @@ With the Docker image user can tryout the Eiffel-Intelligence frontend on a Dock
 
 
 This will produce a war file in the "target" folder.
+
+
 2. Build the Docker image with the war file that was produced from previous step: 
 
 
@@ -33,29 +35,32 @@ To run the produced docker image on the local Docker host, execute this command:
 
 `docker run -p 8034:8091 --expose 8091 -e server.port=8091 -e logging.level.root=DEBUG -e logging.level.org.springframework.web=DEBUG -e logging.level.com.ericsson.ei=DEBUG eiffel-intelligence-backend:0.1`
 
-Some info of all flags to this command: 
+# Some info of all flags to this command
 
 
-Eiffel Intelligence Spring Properties:
+## Eiffel Intelligence Spring Properties
 
 
-"-e server.port=8091" - Is the Spring property setting for Eiffel-Intelligence applications web port.
+<B>"-e server.port=8091"</B> - Is the Spring property setting for Eiffel-Intelligence applications web port.
 
 
-"-e logging.level.root=DEBUG -e logging.level.org.springframework.web=DEBUG -e 
-logging.level.com.ericsson.ei=DEBUG" - These Spring properties set the logging level for the Eiffel-Intelligence applications. 
+<B>"-e logging.level.root=DEBUG -e logging.level.org.springframework.web=DEBUG -e 
+logging.level.com.ericsson.ei=DEBUG"</B> - These Spring properties set the logging level for the Eiffel-Intelligence applications. 
 
 
 It is possible to set all Spring available properties via docker environment "-e" flag. See the application.properties file for all available Eiffel-Intelligence Spring properties.
 
 
-Docker flags:
+[application.properties](https://github.com/Ericsson/eiffel-intelligence/blob/master/src/main/resources/application.properties)
 
 
-"--expose 8091" - this Docker flag tells that containers internal port shall be exposed to outside of the Docker Host. This flag do not set which port that should be allocated outside Docker Host on the acual server/machine.
+## Docker flags
 
 
-"-p 8034:8091" - this Docker flag is mapping the containers exposed port to a port number that will be allocated outside Docker host. 8091 is the exposed port in the container. 8034 is the port number that port number that will be allocated outside Docker host and mapped to the Docker Host internal exposed port number 8091.
+<B>"--expose 8091"</B> - this Docker flag tells that containers internal port shall be exposed to outside of the Docker Host. This flag do not set which port that should be allocated outside Docker Host on the actual server/machine.
+
+
+<B>"-p 8034:8091"</B> - this Docker flag is mapping the containers external port 8034 to the internal exposed port 8091. Port 8034 will be allocated outside Docker host and user will be able to access the containers service via port 8034.
 
 
 When Eiffel-Intelligence container is running on your local Docker host Eiffel-Intelligence should be reachable with address "localhost:8091/\<Rest End-Point\>" or "\<docker host ip\>:8091/\<Rest End-Point\>"

--- a/wiki/markdown/docker.md
+++ b/wiki/markdown/docker.md
@@ -1,0 +1,68 @@
+# Docker
+
+In Eiffel-Intelligence frontend source code a Dockerfile is provided which helps the developer or user to build the local Eiffel-Intellegence frontend source code changes to a Docker image.
+With the Docker image user can tryout the Eiffel-Intelligence frontend on a Docker Host or in a Kubernetes cluster.
+
+## Requirements
+- Docker 
+
+
+  Linux: https://docs.docker.com/install/linux/docker-ce/ubuntu/
+
+  
+  Windows: https://docs.docker.com/docker-for-windows/install/
+
+## Follow these step to build the Docker image.
+
+1. Build the Eiffel-Intelligence frontend war file: 
+`mvn package -DskipTests` 
+
+
+This will produce a war file in the "target" folder.
+2. Build the Docker image with the war file that was produced from previous step: 
+
+
+`docker build -f src/main/docker/Dockerfile -t eiffel-intelligence-frontend:0.1 .` 
+
+
+Now docker image has build with tag "eiffel-intelligence-frontend:0.1"
+
+## Run Docker image on local Docker Host
+To run the produced docker image on the local Docker host, execute this command: 
+
+
+`docker run -p 8034:8091 --expose 8091 -e server.port=8091 -e logging.level.root=DEBUG -e logging.level.org.springframework.web=DEBUG -e logging.level.com.ericsson.ei=DEBUG eiffel-intelligence-backend:0.1`
+
+Some info of all flags to this command: 
+
+
+Eiffel Intelligence Spring Properties:
+
+
+"-e server.port=8091" - Is the Spring property setting for Eiffel-Intelligence applications web port.
+
+
+"-e logging.level.root=DEBUG -e logging.level.org.springframework.web=DEBUG -e 
+logging.level.com.ericsson.ei=DEBUG" - These Spring properties set the logging level for the Eiffel-Intelligence applications. 
+
+
+It is possible to set all Spring available properties via docker environment "-e" flag. See the application.properties file for all available Eiffel-Intelligence Spring properties.
+
+
+Docker flags:
+
+
+"--expose 8091" - this Docker flag tells that containers internal port shall be exposed to outside of the Docker Host. This flag do not set which port that should be allocated outside Docker Host on the acual server/machine.
+
+
+"-p 8034:8091" - this Docker flag is mapping the containers exposed port to a port number that will be allocated outside Docker host. 8091 is the exposed port in the container. 8034 is the port number that port number that will be allocated outside Docker host and mapped to the Docker Host internal exposed port number 8091.
+
+
+When Eiffel-Intelligence container is running on your local Docker host Eiffel-Intelligence should be reachable with address "localhost:8091/\<Rest End-Point\>" or "\<docker host ip\>:8091/\<Rest End-Point\>"
+
+
+In web-browser use url with docker host ip number: "\<docker host ip\>:8091/"
+
+Swich-backend functionality do not work when "localhost" address is used.
+
+

--- a/wiki/site.xml
+++ b/wiki/site.xml
@@ -44,6 +44,7 @@
             <item name="Subscription handling" href="Subscription-Handling.html" />
             <item name="Test rules" href="Test-Rules.html" />
             <item name="Curl Examples" href="Front-end_with_curl.html" />
+            <item name="Docker" href="docker.html" />
         </menu>
 
         <footer/>


### PR DESCRIPTION
### Description of the Change
Dockerfile for building Eiffel-Intelligence frontend docker image.

Eiffel-Intelligence Frotend image is built with this command. Uses local EI code changes:
docker build -f src/main/docker/Dockerfile -t eiffel-intelligence-backend:0.1 .

Run EI image/container with following command:
docker run -p 8034:8091 --expose 8091 --network=eiffel2_eiffel_2.0_1 -e server.port=8091 -e logging.level.root=DEBUG -e logging.level.org.springframework.web=DEBUG -e logging.level.com.ericsson.ei=DEBUG eiffel-intelligence-frontend:0.1

With following command example you should be able to access EI RestApi interface wiith address:
localhost:8034/(RestApi end points) or (docker-host ip address):8034/(RestApi end points)

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: <!-- <Your full name> <your-email@example.org> -->
