### PR TITLE
Fix problem with addition of multiple default back-ends

### DIFF
--- a/src/main/java/com/ericsson/ei/frontend/utils/BackEndInstancesUtils.java
+++ b/src/main/java/com/ericsson/ei/frontend/utils/BackEndInstancesUtils.java
@@ -113,10 +113,10 @@ public class BackEndInstancesUtils {
     public boolean hasDefaultBackend() {
         for (BackEndInformation backendInformation : backEndInformationList) {
             if (backendInformation.isDefaultBackend()) {
-                return false;
+                return true;
             }
         }
-        return true;
+        return false;
     }
 
     /**


### PR DESCRIPTION

### Applicable Issues
If EI frontend has a defined default backend (added from GUI) and a new default backend is added with curl this is added to list of backends. Problem is that EI frontend now has 2 default backends which are both active.

EI frontend should not have multiple default backends.

### Description of the Change
Fixed one if statement so that it returns true when it finds a default back-end in the list.

### Alternate Designs

### Benefits

### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Jakub Binieda, jakub.binieda@ericsson.com
