### PR TITLE
Add timer and check for requests in query integration test

### DIFF
--- a/src/integrationtest/java/com/ericsson/ei/frontend/CommonSteps.java
+++ b/src/integrationtest/java/com/ericsson/ei/frontend/CommonSteps.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertEquals;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Paths;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import org.apache.commons.io.FileUtils;
@@ -139,6 +140,16 @@ public class CommonSteps extends AbstractTestExecutionListener {
         response = httpRequest.performRequest();
     }
 
+    @When("^request is sent til body \'(.*)\' is not received$")
+    public void request_sent_body_not_received(String received) throws Throwable {
+        response = httpRequest.performRequest();
+        long stopTime = System.currentTimeMillis() + 30000;
+        while (response.getBody().equalsIgnoreCase(received) && stopTime > System.currentTimeMillis()) {
+            response = httpRequest.performRequest();
+        }
+        assertEquals(true, !response.getBody().equalsIgnoreCase(received));
+    }
+
     @Then("^response code (\\d+) is received$")
     public void get_response_code(int statusCode) throws Throwable {
         LOGGER.debug("Response code: {}", response.getStatusCode());
@@ -163,6 +174,7 @@ public class CommonSteps extends AbstractTestExecutionListener {
     @Then("^response body contains \'(.*)\'$")
     public void response_body_contains(String contains) throws Throwable {
         LOGGER.debug("Response body: {}", response.getBody());
+        LOGGER.debug("Contains: {}", contains);
         assertEquals(true, response.getBody().contains(contains));
     }
 }

--- a/src/integrationtest/java/com/ericsson/ei/frontend/CommonSteps.java
+++ b/src/integrationtest/java/com/ericsson/ei/frontend/CommonSteps.java
@@ -142,7 +142,7 @@ public class CommonSteps extends AbstractTestExecutionListener {
 
     @When("^request is sent for (\\d+) seconds until reponse code no longer matches (\\d+)$")
     public void request_sent_body_not_received(int seconds, int statusCode) throws Throwable {
-        long stopTime = System.currentTimeMillis() + seconds * 1000;
+        long stopTime = System.currentTimeMillis() + (seconds * 1000);
         do {
             response = httpRequest.performRequest();
         } while (response.getStatusCode().value() == statusCode && stopTime > System.currentTimeMillis());

--- a/src/integrationtest/java/com/ericsson/ei/frontend/CommonSteps.java
+++ b/src/integrationtest/java/com/ericsson/ei/frontend/CommonSteps.java
@@ -140,14 +140,13 @@ public class CommonSteps extends AbstractTestExecutionListener {
         response = httpRequest.performRequest();
     }
 
-    @When("^request is sent til body \'(.*)\' is not received$")
-    public void request_sent_body_not_received(String received) throws Throwable {
-        response = httpRequest.performRequest();
-        long stopTime = System.currentTimeMillis() + 30000;
-        while (response.getBody().equalsIgnoreCase(received) && stopTime > System.currentTimeMillis()) {
+    @When("^request is sent for (\\d+) seconds until reponse code no longer matches (\\d+)$")
+    public void request_sent_body_not_received(int seconds, int statusCode) throws Throwable {
+        long stopTime = System.currentTimeMillis() + seconds * 1000;
+        do {
             response = httpRequest.performRequest();
-        }
-        assertEquals(true, !response.getBody().equalsIgnoreCase(received));
+        } while (response.getStatusCode().value() == statusCode && stopTime > System.currentTimeMillis());
+        assertEquals(HttpStatus.OK, response.getStatusCode());
     }
 
     @Then("^response code (\\d+) is received$")

--- a/src/integrationtest/resources/bodies/subscription_single.json
+++ b/src/integrationtest/resources/bodies/subscription_single.json
@@ -35,7 +35,7 @@
         "type": "ARTIFACT_1"
       }
     ],
-    "subscriptionName": "Subscription_Test",
+    "subscriptionName": "Subscription_IT",
     "userName": "ABC"
   }
 ]

--- a/src/integrationtest/resources/bodies/subscription_single_modify.json
+++ b/src/integrationtest/resources/bodies/subscription_single_modify.json
@@ -35,7 +35,7 @@
         "type": "ARTIFACT_1"
       }
     ],
-    "subscriptionName": "Subscription_Test",
+    "subscriptionName": "Subscription_IT",
     "userName": "ABC"
   }
 ]

--- a/src/integrationtest/resources/features/query.feature
+++ b/src/integrationtest/resources/features/query.feature
@@ -16,8 +16,7 @@ Feature: Query test
     And an aggregated object is created
     When a 'GET' request is prepared for REST API '/queryAggregatedObject'
     And param key 'ID' with value '6acc3c87-75e0-4b6d-88f5-b1a5d4e62b43' is added
-    And request is sent til body '{"responseEntity":"[]"}' is not received
-    Then response code 200 is received
+    And request is sent for 30 seconds until reponse code no longer matches 204
     And response body contains '6acc3c87-75e0-4b6d-88f5-b1a5d4e62b43'
 
   @QueryFreestyleScenario
@@ -26,6 +25,5 @@ Feature: Query test
     And an aggregated object is created
     When a 'POST' request is prepared for REST API '/query'
     And body is set to file 'queryFreestyle.json'
-    And request is sent til body '[]' is not received
-    Then response code 200 is received
+    And request is sent for 30 seconds until reponse code no longer matches 204
     And response body contains '6acc3c87-75e0-4b6d-88f5-b1a5d4e62b43'

--- a/src/integrationtest/resources/features/query.feature
+++ b/src/integrationtest/resources/features/query.feature
@@ -16,7 +16,7 @@ Feature: Query test
     And an aggregated object is created
     When a 'GET' request is prepared for REST API '/queryAggregatedObject'
     And param key 'ID' with value '6acc3c87-75e0-4b6d-88f5-b1a5d4e62b43' is added
-    And request is sent
+    And request is sent til body '{"responseEntity":"[]"}' is not received
     Then response code 200 is received
     And response body contains '6acc3c87-75e0-4b6d-88f5-b1a5d4e62b43'
 
@@ -26,6 +26,6 @@ Feature: Query test
     And an aggregated object is created
     When a 'POST' request is prepared for REST API '/query'
     And body is set to file 'queryFreestyle.json'
-    And request is sent
+    And request is sent til body '[]' is not received
     Then response code 200 is received
     And response body contains '6acc3c87-75e0-4b6d-88f5-b1a5d4e62b43'

--- a/src/integrationtest/resources/features/subscriptions.feature
+++ b/src/integrationtest/resources/features/subscriptions.feature
@@ -23,7 +23,7 @@ Feature: Subscriptions test
   Scenario: Get subscription
     Given frontend is up and running
     When a 'GET' request is prepared for REST API '/subscriptions'
-    And '/Subscription_Test' is appended to endpoint
+    And '/Subscription_IT' is appended to endpoint
     And username "gauss" and password "password" is used as credentials
     And request is sent
     Then response code 200 is received
@@ -33,7 +33,7 @@ Feature: Subscriptions test
   Scenario: Delete subscription
     Given frontend is up and running
     When a 'DELETE' request is prepared for REST API '/subscriptions'
-    And '/Subscription_Test' is appended to endpoint
+    And '/Subscription_IT' is appended to endpoint
     And username "gauss" and password "password" is used as credentials
     And request is sent
     Then response code 200 is received


### PR DESCRIPTION

### Applicable Issues

### Description of the Change
Adds a timer and a body check for query integration test

### Alternate Designs

### Benefits
Added to prevent the test from doing a query before the aggregated object exists.

### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Christoffer Cortes Sjöwall, christoffer.cortes.sjowall@ericsson.com
