### PR TITLE
Add -B flag in travis file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ after_script:
 
 before_deploy:
   - rm -rf docs
-  - mvn site
+  - mvn site -B
   - mvn clean
 
 deploy:


### PR DESCRIPTION
This disables the downloading progress of the mvn site command

### Applicable Issues
When mvn site command downloaded dependencies the progress bar showed in the travis log causing it to become too big. 

### Description of the Change
Added a -B flag to mvn site command.

### Benefits
This flag disables the progress bar showing.

### Sign-off


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Emelie Pettersson emelie.pettersson@ericsson.com
