### PR TITLE
Remove unused configuration for mvn clean plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -316,27 +316,13 @@
                                 <resource>
                                     <directory>${basedir}/wiki/markdown/images</directory>
                                     <includes>
-                                    	<include>*.png</include>
+                                        <include>*.png</include>
                                     </includes>
                                 </resource>
                             </resources>
                         </configuration>
                     </execution>
                 </executions>
-            </plugin>
-
-            <plugin>
-                <artifactId>maven-clean-plugin</artifactId>
-                <version>3.1.0</version>
-                <!-- We want to remove duplicate/copied resources from site
-                    generation -->
-                <configuration>
-                    <filesets>
-                        <fileset>
-                            <directory>${basedir}/wiki/resources</directory>
-                        </fileset>
-                    </filesets>
-                </configuration>
             </plugin>
 
         </plugins>


### PR DESCRIPTION
### Applicable Issues
We've changed how images are copied to be available for mvn site plugin, thus we no longer need the mvn clean plugin configuration.

### Description of the Change
Removed the unused configuration for mvn clean plugin.


### Benefits
Less configuration in pom file.


### Sign-off


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Emelie Pettersson emelie.pettersson@ericsson.com
