### PR TITLE
Step up rabbitmq and exclude files from test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -161,7 +161,7 @@
         <dependency>
             <groupId>com.rabbitmq</groupId>
             <artifactId>amqp-client</artifactId>
-            <version>5.1.2</version>
+            <version>5.4.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -239,8 +239,11 @@
                     <reuseForks>false</reuseForks>
                     <useSystemClassLoader>false</useSystemClassLoader>
                     <excludes>
-                        <exclude>**/*IT.java</exclude>
                         <exclude>${someModule.test.excludes}</exclude>
+                        <exclude>**/*IT.java</exclude>
+                        <exclude>TestBaseClass</exclude>
+                        <exclude>SeleniumBaseClass</exclude>
+                        <exclude>CommonSteps</exclude>
                     </excludes>
                     <includes>
                         <include>${someModule.test.includes}</include>


### PR DESCRIPTION
### Applicable Issues
https://github.com/eiffel-community/eiffel-intelligence-frontend/network/alert/pom.xml/com.rabbitmq:amqp-client/open

### Description of the Change
RabbitMQ is now 5.4.0 to close the vulnerability alert. Some classes have been specifically excluded from surefire so that they no longer appear as skipped.

### Alternate Designs

### Benefits

### Possible Drawbacks

### Sign-off
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Christoffer Cortes Sjöwall, [christoffer.cortes.sjowall@ericsson.com](mailto:christoffer.cortes.sjowall@ericsson.com)
