### PR TITLE
Add jenkins jobs sending Eiffel events for Source Change system tests

### DIFF
--- a/src/systemtest/java/com/ericsson/ei/systemtest/sourcechangeflow/SourceChangeFlowRunner.java
+++ b/src/systemtest/java/com/ericsson/ei/systemtest/sourcechangeflow/SourceChangeFlowRunner.java
@@ -1,0 +1,13 @@
+package com.ericsson.ei.systemtest.sourcechangeflow;
+
+import org.junit.runner.RunWith;
+
+import cucumber.api.CucumberOptions;
+import cucumber.api.junit.Cucumber;
+
+@RunWith(Cucumber.class)
+@CucumberOptions(features = "src/systemtest/resources/features/SourceChangeFlow.feature", glue = {
+        "com.ericsson.ei.systemtest.sourcechangeflow" }, plugin = { "pretty",
+        "html:target/cucumber-reports/SourceChangeFlow"})
+public class SourceChangeFlowRunner {
+}

--- a/src/systemtest/java/com/ericsson/ei/systemtest/sourcechangeflow/SourceChangeFlowSteps.java
+++ b/src/systemtest/java/com/ericsson/ei/systemtest/sourcechangeflow/SourceChangeFlowSteps.java
@@ -18,7 +18,6 @@ import static junit.framework.TestCase.assertTrue;
 public class SourceChangeFlowSteps extends AbstractTestExecutionListener {
     private static final Logger LOGGER = LoggerFactory.getLogger(SourceChangeFlowSteps.class);
     private static final String JENKINS_TOKEN = "123";
-    private static final String JENKINS_JOB_XML = "jenkinsJobTemplate.xml";
 
     private ArrayList<String> jenkinsJobNames = new ArrayList<String>();
     private Config config = new Config();

--- a/src/systemtest/java/com/ericsson/ei/systemtest/sourcechangeflow/SourceChangeFlowSteps.java
+++ b/src/systemtest/java/com/ericsson/ei/systemtest/sourcechangeflow/SourceChangeFlowSteps.java
@@ -1,0 +1,59 @@
+package com.ericsson.ei.systemtest.sourcechangeflow;
+
+import com.ericsson.ei.systemtest.utils.Config;
+import com.ericsson.ei.systemtest.utils.StepsUtils;
+import cucumber.api.java.en.Given;
+import cucumber.api.java.en.Then;
+import org.junit.Ignore;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.test.context.support.AbstractTestExecutionListener;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static junit.framework.TestCase.assertTrue;
+
+@Ignore
+public class SourceChangeFlowSteps extends AbstractTestExecutionListener {
+    private static final Logger LOGGER = LoggerFactory.getLogger(SourceChangeFlowSteps.class);
+    private static final String JENKINS_TOKEN = "123";
+    private static final String JENKINS_JOB_XML = "jenkinsJobTemplate.xml";
+
+    private ArrayList<String> jenkinsJobNames = new ArrayList<String>();
+    private Config config = new Config();
+
+    @Given("^configurations are provided$")
+    public void configurations_are_provided() {
+        config.initEIFrontend();
+        config.initEIBackend();
+        config.initJenkinsConfig();
+        config.initRemRemConfig();
+    }
+
+    @Given("^a jenkins job '\\\"([^\\\"]*)\\\"' from '\"([^\"]*)\"' is created with parameters: (.*)$")
+    public void a_jenkins_job_from_is_created(String jenkinsJobName, String scriptFileName, List<String> parameters) throws Throwable {
+        boolean success = StepsUtils.createJenkinsJob(
+                jenkinsJobName,
+                scriptFileName,
+                config.getJenkinsBaseUrl(),
+                config.getJenkinsUsername(),
+                config.getJenkinsPassword(),
+                config.getRemremBaseUrl(),
+                JENKINS_TOKEN,
+                parameters
+        );
+
+        if (success) {
+            jenkinsJobNames.add(jenkinsJobName);
+        }
+
+        assertTrue("Failed to create jenkins job.", success);
+    }
+
+    @Then("^subscriptions and jenkins jobs should be removed$")
+    public void subscriptions_and_jenkins_jobs_should_be_removed() throws Throwable {
+        StepsUtils.deleteJenkinsJobs(jenkinsJobNames);
+        //StepsUtils.deleteSubscriptions(config.getEiFrontendBaseUrl(), config.getEiBackendBaseUrl());
+    }
+}

--- a/src/systemtest/resources/JenkinsShellScripts/ActSFCScript.txt
+++ b/src/systemtest/resources/JenkinsShellScripts/ActSFCScript.txt
@@ -1,0 +1,130 @@
+import groovy.json.JsonSlurper
+def baseUrl = "REMREM_BASE_URL_TO_BE_REPLACED";
+
+
+////////////////////////////////////////////////////////////////////////////////////////
+///////////////////////////////////////ActS1////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////////
+
+uriPathActS1 = baseUrl + "/generateAndPublish?mp=eiffelsemantics&msgType=EiffelActivityStartedEvent";
+jsonActS1 = """{
+  "msgParams": {
+   "meta": {
+     "type": "EiffelActivityStartedEvent",
+     "version": "1.1.0",
+     "tags": [],
+     "source": {
+       "domainId": "",
+       "host": "",
+       "name": "",
+       "uri": ""
+     }
+   }
+  },
+  "eventParams": {
+    "data": {
+     "executionUri": ""
+    },
+   "links": [
+     {
+       "type": "ACTIVITY_EXECUTION",
+       "target": \""""+ build.environment.EVENT_ID + """\"
+     }
+   ]
+  }
+}"""
+
+ActS1ID = generateEiffelEventAndPublish(uriPathActS1, jsonActS1);
+
+
+////////////////////////////////////////////////////////////////////////////////////////
+///////////////////////////////////////ActF1////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////////
+
+uriPathActF1 = baseUrl + "/generateAndPublish?mp=eiffelsemantics&msgType=EiffelActivityFinishedEvent";
+jsonActF1 = """{
+  "msgParams": {
+    "meta": {
+     "type": "EiffelActivityFinishedEvent",
+     "version": "1.1.0",
+     "tags": [],
+     "source": {
+       "domainId": "",
+       "host": "",
+       "name": "",
+       "uri": ""
+     }
+   }
+  },
+  "eventParams": {
+    "data": {
+     "outcome": {
+       "conclusion": "SUCCESSFUL",
+       "description": ""
+     }
+    },
+    "links": [
+      {
+        "type": "ACTIVITY_EXECUTION",
+        "target": \""""+ build.environment.EVENT_ID + """\"
+      }
+    ]
+  }
+}"""
+
+ActF1ID = generateEiffelEventAndPublish(uriPathActF1, jsonActF1);
+
+
+
+////////////////////////////////////////////////////////////////////////////////////////
+///////////////////////////////////////ActC1////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////////
+
+uriPathActC1 = baseUrl + "/generateAndPublish?mp=eiffelsemantics&msgType=EiffelActivityCanceledEvent";
+jsonActC1 = """{
+  "msgParams": {
+    "meta": {
+     "type": "EiffelActivityCanceledEvent",
+     "version": "1.1.0",
+     "tags": [],
+     "source": {
+       "domainId": "",
+       "host": "",
+       "name": "",
+       "uri": ""
+     }
+    }
+  },
+  "eventParams": {
+    "data": {
+     "reason": ""
+    },
+    "links": [
+      {
+        "type": "ACTIVITY_EXECUTION",
+        "target": \""""+ build.environment.EVENT_ID + """\"
+      }
+    ]
+  }
+}"""
+
+
+ActC1ID = generateEiffelEventAndPublish(uriPathActC1, jsonActC1);
+
+
+
+def generateEiffelEventAndPublish(uriPath, json){
+  def post = new URL(uriPath).openConnection();
+  def message = json
+  post.setRequestMethod("POST")
+  post.setDoOutput(true)
+  post.setRequestProperty("Content-Type", "application/json")
+  post.getOutputStream().write(message.getBytes("UTF-8"));
+
+  responseText = post.getInputStream().getText();
+
+  def jsonSlurper = new JsonSlurper()
+  responseJson = jsonSlurper.parseText(responseText);
+  return responseJson["events"][0]["id"].toString();
+}
+

--- a/src/systemtest/resources/JenkinsShellScripts/ActT1Script.txt
+++ b/src/systemtest/resources/JenkinsShellScripts/ActT1Script.txt
@@ -1,0 +1,63 @@
+import groovy.json.JsonSlurper
+def baseUrl = "REMREM_BASE_URL_TO_BE_REPLACED";
+
+
+////////////////////////////////////////////////////////////////////////////////////////
+///////////////////////////////////////ActT1////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////////
+
+uriPathActT1 = baseUrl + "/generateAndPublish?mp=eiffelsemantics&msgType=EiffelActivityTriggeredEvent";
+jsonActT1 = """{
+  "msgParams": {
+    "meta": {
+      "type": "EiffelActivityTriggeredEvent",
+      "version": "1.1.0",
+      "tags": [],
+      "source": {
+        "domainId": "",
+        "host": "",
+        "name": "",
+        "uri": ""
+      }
+    }
+  },
+  "eventParams": {
+    "data": {
+      "name": "required",
+      "categories": [],
+      "triggers": [
+        {
+          "type": "SOURCE_CHANGE",
+          "description": ""
+        }
+      ],
+      "executionType": "AUTOMATED"
+    },
+    "links": [
+      {
+        "type": "CAUSE",
+        "target": \""""+ build.environment.EVENT_ID + """\"
+      }
+    ]
+  }
+}"""
+
+
+ActT1ID = generateEiffelEventAndPublish(uriPathActT1, jsonActT1);
+
+
+
+def generateEiffelEventAndPublish(uriPath, json){
+  def post = new URL(uriPath).openConnection();
+  def message = json
+  post.setRequestMethod("POST")
+  post.setDoOutput(true)
+  post.setRequestProperty("Content-Type", "application/json")
+  post.getOutputStream().write(message.getBytes("UTF-8"));
+
+  responseText = post.getInputStream().getText();
+
+  def jsonSlurper = new JsonSlurper()
+  responseJson = jsonSlurper.parseText(responseText);
+  return responseJson["events"][0]["id"].toString();
+}

--- a/src/systemtest/resources/JenkinsShellScripts/SCS1Script.txt
+++ b/src/systemtest/resources/JenkinsShellScripts/SCS1Script.txt
@@ -1,0 +1,187 @@
+import groovy.json.JsonSlurper
+def baseUrl = "REMREM_BASE_URL_TO_BE_REPLACED";
+
+
+////////////////////////////////////////////////////////////////////////////////////////
+///////////////////////////////////////SCC1/////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////////
+
+uriPathSCC1 = baseUrl + "/generateAndPublish?mp=eiffelsemantics&msgType=EiffelSourceChangeCreatedEvent";
+jsonSCC1 = """{
+  "msgParams": {
+    "meta": {
+     "type": "EiffelSourceChangeCreatedEvent",
+     "version": "1.1.0",
+     "tags": [],
+     "source": {
+       "domainId": "",
+       "host": "",
+       "name": "",
+       "uri": ""
+     }
+    }
+  },
+  "eventParams": {
+    "data": {
+      "author": {
+       "name": "",
+       "email": "",
+       "id": "",
+       "group": ""
+      },
+      "gitIdentifier": {
+       "commitId": "commitID",
+       "branch": "",
+       "repoName": "",
+       "repoUri": "required"
+      },
+      "svnIdentifier": {
+       "revision": "1",
+       "directory": "required",
+       "repoName": "",
+       "repoUri": "required"
+      },
+      "hgIdentifier": {
+       "commitId": "required",
+       "branch": "",
+       "repoName": "",
+       "repoUri": "required"
+      }
+    }
+  }
+}"""
+
+SCC1ID = generateEiffelEventAndPublish(uriPathSCS1, jsonSCS1);
+
+////////////////////////////////////////////////////////////////////////////////////////
+///////////////////////////////////////SCC2/////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////////
+
+uriPathSCC2 = baseUrl + "/generateAndPublish?mp=eiffelsemantics&msgType=EiffelSourceChangeCreatedEvent";
+jsonSCC2 = """{
+  "msgParams": {
+    "meta": {
+    "type": "EiffelSourceChangeCreatedEvent",
+    "version": "1.1.0",
+    "tags": [],
+    "source": {
+      "domainId": "",
+      "host": "",
+      "name": "",
+      "uri": ""
+    }
+  }
+  },
+  "eventParams": {
+    "data": {
+     "author": {
+      "name": "",
+      "email": "",
+      "id": "",
+      "group": ""
+     },
+     "gitIdentifier": {
+      "commitId": "commitID",
+      "branch": "",
+      "repoName": "",
+      "repoUri": "required"
+     },
+     "svnIdentifier": {
+      "revision": "2",
+      "directory": "required",
+      "repoName": "",
+      "repoUri": "required"
+     },
+     "hgIdentifier": {
+      "commitId": "required",
+      "branch": "",
+      "repoName": "",
+      "repoUri": "required"
+     }
+    },
+    "links": [
+      {
+        "type": "PREVIOUS_VERSION",
+        "target": \""""+ SCC1ID + """\"
+      }
+    ]
+  }
+}"""
+
+SCC2ID = generateEiffelEventAndPublish(uriPathSCS1, jsonSCS1);
+
+
+////////////////////////////////////////////////////////////////////////////////////////
+///////////////////////////////////////SCS1/////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////////
+
+uriPathSCS1 = baseUrl + "/generateAndPublish?mp=eiffelsemantics&msgType=EiffelSourceChangeSubmittedEvent";
+jsonSCS1 = """
+{
+  "msgParams": {
+    "meta": {
+      "type": "EiffelSourceChangeSubmittedEvent",
+      "version": "1.1.0",
+      "tags": [],
+      "source": {
+        "domainId": "",
+        "host": "",
+        "name": "",
+        "uri": ""
+      }
+    }
+  },
+  "eventParams": {
+    "data": {
+      "submitter": {
+        "name": "",
+        "email": "",
+        "id": "",
+        "group": ""
+      },
+      "gitIdentifier": {
+        "commitId": "commitID ",
+        "repoUri": "my-repo",
+        "branch": "",
+        "repoName": ""
+      },
+      "svnIdentifier": {
+        "revision": "1",
+        "directory": "required",
+        "repoName": "",
+        "repoUri": "required"
+      },
+      "hgIdentifier": {
+        "commitId": "required",
+        "branch": "",
+        "repoName": "",
+        "repoUri": "required"
+      }
+    },
+    "links": [
+      {
+       "type": "CHANGE",
+       "target": \""""+ SCC2ID + """\"
+      }
+    ]
+  }
+}"""
+
+SCS1ID = generateEiffelEventAndPublish(uriPathSCS1, jsonSCS1);
+
+
+
+def generateEiffelEventAndPublish(uriPath, json){
+  def post = new URL(uriPath).openConnection();
+  def message = json
+  post.setRequestMethod("POST")
+  post.setDoOutput(true)
+  post.setRequestProperty("Content-Type", "application/json")
+  post.getOutputStream().write(message.getBytes("UTF-8"));
+
+  responseText = post.getInputStream().getText();
+
+  def jsonSlurper = new JsonSlurper()
+  responseJson = jsonSlurper.parseText(responseText);
+  return responseJson["events"][0]["id"].toString();
+}

--- a/src/systemtest/resources/features/SourceChangeFlow.feature
+++ b/src/systemtest/resources/features/SourceChangeFlow.feature
@@ -1,0 +1,20 @@
+@SourceChangeFlowFeature
+Feature: Source Change system test
+
+  @SourceChangeFlowScenario
+  Scenario: Creates jenkins jobs, subscriptions and at last see that the last job has been
+            triggered in order to know if all events has been aggregated correctly.
+
+    Given configurations are provided
+
+    # A bunch of Jenkins job will be created here
+    Then a jenkins job '"SCS1Job"' from '"src/systemtest/resources/JenkinsShellScripts/SCS1Script.txt"' is created with parameters: ,
+    And a jenkins job '"ActT1Job"' from '"src/systemtest/resources/JenkinsShellScripts/ActT1Script.txt"' is created with parameters: EVENT_ID,
+    And a jenkins job '"ActSFCJob"' from '"src/systemtest/resources/JenkinsShellScripts/ActSFCScript.txt"' is created with parameters: EVENT_ID,
+    And a jenkins job '"CLMJob"' from '"src/systemtest/resources/JenkinsShellScripts/CLMScript.txt"' is created with parameters: EVENT_ID,
+
+    # Subscriptions will be created here
+
+
+    # Check everything has been triggered
+    And subscriptions and jenkins jobs should be removed

--- a/src/systemtest/resources/features/SourceChangeFlow.feature
+++ b/src/systemtest/resources/features/SourceChangeFlow.feature
@@ -6,15 +6,13 @@ Feature: Source Change system test
             triggered in order to know if all events has been aggregated correctly.
 
     Given configurations are provided
-
-    # A bunch of Jenkins job will be created here
     Then a jenkins job '"SCS1Job"' from '"src/systemtest/resources/JenkinsShellScripts/SCS1Script.txt"' is created with parameters: ,
     And a jenkins job '"ActT1Job"' from '"src/systemtest/resources/JenkinsShellScripts/ActT1Script.txt"' is created with parameters: EVENT_ID,
     And a jenkins job '"ActSFCJob"' from '"src/systemtest/resources/JenkinsShellScripts/ActSFCScript.txt"' is created with parameters: EVENT_ID,
     And a jenkins job '"CLMJob"' from '"src/systemtest/resources/JenkinsShellScripts/CLMScript.txt"' is created with parameters: EVENT_ID,
 
-    # Subscriptions will be created here
+    ### Add Subscription to EI ###
 
 
-    # Check everything has been triggered
+    ### Check everything has been triggered ###
     And subscriptions and jenkins jobs should be removed


### PR DESCRIPTION
### Applicable Issues
No system tests defined for source change flows previously.

### Description of the Change
Add skeleton for source change flow system tests.
Add steps which creates Jenkins jobs sending Eiffel events for the source change flow.

### Benefits
Started on new system tests...
Closes #172 

### Possible Drawbacks
None.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Emelie Pettersson emelie.pettersson@ericsson.com
