### PR TITLE
Fix content/data-type on ajax request

### DIFF
--- a/src/main/resources/static/js/eiInfo.js
+++ b/src/main/resources/static/js/eiInfo.js
@@ -178,8 +178,10 @@ jQuery(document).ready(function () {
             }
         };
         var ajaxHttpSender = new AjaxHttpSender();
+        var contentType = "application/string; charset=utf-8";
+        var datatype = "text";
         var contextPath = "/auth/checkStatus";
-        ajaxHttpSender.sendAjax(contextPath, "GET", null, callback);
+        ajaxHttpSender.sendAjax(contextPath, "GET", null, callback, contentType, datatype);
     }
     checkBackendStatus();
 

--- a/src/main/resources/static/js/testrules.js
+++ b/src/main/resources/static/js/testrules.js
@@ -349,8 +349,10 @@ jQuery(document).ready(function () {
             }
         };
         var ajaxHttpSender = new AjaxHttpSender();
+        var contentType = "application/string; charset=utf-8";
+        var datatype = "text";
         var contextPath = "/auth/checkStatus";
-        ajaxHttpSender.sendAjax(contextPath, "GET", null, callback);
+        ajaxHttpSender.sendAjax(contextPath, "GET", null, callback, contentType, datatype);
     }
     checkBackendStatus();
 


### PR DESCRIPTION
### Applicable Issues
Incorrect content/data-type for checkStatus ajax requests.
Caused test rules and ei info pages to get an error in the request.

### Description of the Change

### Alternate Designs

### Benefits

### Possible Drawbacks

### Sign-off
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Christoffer Cortes Sjöwall, [christoffer.cortes.sjowall@ericsson.com](mailto:christoffer.cortes.sjowall@ericsson.com)
