### PR TITLE
Fix nullpointer bug with EI-frontend systemtests

### DIFF
--- a/src/systemtest/java/com/ericsson/ei/systemtest/utils/PropertiesHandler.java
+++ b/src/systemtest/java/com/ericsson/ei/systemtest/utils/PropertiesHandler.java
@@ -14,11 +14,12 @@ public class PropertiesHandler {
     public static void setProperties() throws Throwable {
         final String eiConfigPropertiesFilepath;
 
-        if (System.getProperty("ei.config.properties.file.path") != null) {
-            eiConfigPropertiesFilepath = System.getProperty("ei.config.properties.file.path");
-        } else {
+        if (System.getProperty("ei.config.properties.file.path") == null || System.getProperty("ei.config.properties.file.path").equals("")) {
             eiConfigPropertiesFilepath = "src/systemtest/resources/system-test.properties";
+        } else {
+            eiConfigPropertiesFilepath = System.getProperty("ei.config.properties.file.path");
         }
+
         InputStream systemTestFileInputStream = new FileInputStream(new File(eiConfigPropertiesFilepath));
         Properties systemTestProperties = new Properties();
         systemTestProperties.load(systemTestFileInputStream);


### PR DESCRIPTION
<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests.
-->

### Description of the Change
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the sources addressed by this PR recently, so please walk us through the concepts. -->
- The configuration handler will now use the default path if no
   configuration path is provided. If ran from the command line,
   the environmental variable for the path won't be null but
   an empty string. This change adheres to that.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: <!-- <Your full name> <your-email@example.org> -->
Erik Edling erik.edling@ericsson.com