### PR TITLE
Update frontend tests to use Eiffel events from Agen edition

### DIFF
--- a/src/functionaltest/resources/responses/AggregatedObjectResponse.json
+++ b/src/functionaltest/resources/responses/AggregatedObjectResponse.json
@@ -1,16 +1,16 @@
-[  
-  {  
+[
+  {
     "_id":"df4cdb42-1580-4cff-b97a-4d0faa9b2b22_ARTIFACT_TEST",
-    "aggregatedObject":{  
-      "fileInformation":[  
-        {  
+    "aggregatedObject":{
+      "fileInformation":[
+        {
           "extension":"war",
           "classifier":""
         }
       ],
       "buildCommand":"trigger",
-      "confidenceLevels":[  
-        {  
+      "confidenceLevels":[
+        {
           "eventId":"e3be0cf8-2ebd-4d6d-bf5c-a3b535cd084e_ARTIFACT_TEST",
           "name":"dummy_1_stable",
           "time":1521452400324,
@@ -21,16 +21,12 @@
       "id":"df4cdb42-1580-4cff-b97a-4d0faa9b2b22_ARTIFACT_TEST",
       "time":1521452368194,
       "type":"EiffelArtifactCreatedEvent",
-      "gav":{  
-        "groupId":"someGroup",
-        "artifactId":"someArtifact",
-        "version":"someVersion"
-      },
-      "publications":[  
-        {  
+      "identity": "pkg:maven/com.mycompany.myproduct/artifact-name@1.0.0",
+      "publications":[
+        {
           "eventId":"2acd348d-05e6-4945-b441-dc7c1e55534e_ARTIFACT_TEST",
-          "locations":[  
-            {  
+          "locations":[
+            {
               "type":"NEXUS",
               "uri":"http://host:port/path"
             }

--- a/src/functionaltest/resources/responses/DefaultInstanceSubscriptionResponse.json
+++ b/src/functionaltest/resources/responses/DefaultInstanceSubscriptionResponse.json
@@ -16,7 +16,7 @@
       {
         "conditions":[
           {
-            "jmespath":"gav.groupId=='com.othercompany.library'"
+            "jmespath":"identity=='pkg:maven/com.mycompany.myproduct/artifact-name@1.0.0'"
           }
         ]
       }

--- a/src/functionaltest/resources/responses/EventsTemplateObject.json
+++ b/src/functionaltest/resources/responses/EventsTemplateObject.json
@@ -3,18 +3,14 @@
     "meta": {
       "id": "df4cdb42-1580-4cff-b97a-4d0faa9b2b22",
       "type": "EiffelArtifactCreatedEvent",
-      "version": "1.1.0",
+      "version": "3.0.0",
       "time": 1521452368194,
       "tags": [],
       "source": {
         "domainId": "someDomain",
         "host": "someHost",
         "name": "someName",
-        "serializer": {
-          "groupId": "com.github.Ericsson",
-          "artifactId": "eiffel-remrem-semantics",
-          "version": "0.0.10"
-        },
+        "serializer": "pkg:maven/com.mycompany.tools/eiffel-serializer@1.0.3",
         "uri": "http://host:port/path"
       },
       "security": {
@@ -25,11 +21,7 @@
       }
     },
     "data": {
-      "gav": {
-        "groupId": "someGroup",
-        "artifactId": "someArtifact",
-        "version": "someVersion"
-      },
+      "identity": "pkg:maven/com.mycompany.myproduct/artifact-name@1.0.0",
       "fileInformation": [
         {
           "classifier": "",
@@ -38,13 +30,7 @@
       ],
       "buildCommand": "trigger",
       "requiresImplementation": "NONE",
-      "dependsOn": [
-        {
-          "groupId": "",
-          "artifactId": "",
-          "version": ""
-        }
-      ],
+      "dependsOn": ["pkg:maven/com.mycompany.myproduct/my-interface@%5B1.0%2C2.0%29"],
       "implements": [],
       "name": "event",
       "customData": []
@@ -60,18 +46,14 @@
     "meta": {
       "id": "e3be0cf8-2ebd-4d6d-bf5c-a3b535cd084e",
       "type": "EiffelConfidenceLevelModifiedEvent",
-      "version": "1.1.0",
+      "version": "3.0.0",
       "time": 1521452400324,
       "tags": [],
       "source": {
         "domainId": "someDomain",
         "host": "someHost",
         "name": "someName",
-        "serializer": {
-          "groupId": "com.github.Ericsson",
-          "artifactId": "eiffel-remrem-semantics",
-          "version": "0.0.10"
-        },
+        "serializer": "pkg:maven/com.mycompany.tools/eiffel-serializer@1.0.3",
         "uri": "http://host:port/path"
       },
       "security": {
@@ -103,17 +85,13 @@
     "meta": {
       "id": "2acd348d-05e6-4945-b441-dc7c1e55534e",
       "type": "EiffelArtifactPublishedEvent",
-      "version": "1.1.0",
+      "version": "3.0.0",
       "time": 1521452368758,
       "tags": [],
       "source": {
         "domainId": "someDomain",
         "name": "someName",
-        "serializer": {
-          "groupId": "com.github.Ericsson",
-          "artifactId": "eiffel-remrem-semantics",
-          "version": "0.0.10"
-        }
+        "serializer": "pkg:maven/com.mycompany.tools/eiffel-serializer@1.0.3"
       }
     },
     "data": {

--- a/src/functionaltest/resources/responses/NewInstanceSubscriptionResponse.json
+++ b/src/functionaltest/resources/responses/NewInstanceSubscriptionResponse.json
@@ -16,7 +16,7 @@
       {
         "conditions":[
           {
-            "jmespath":"gav.groupId=='com.othercompany.library'"
+            "jmespath": "identity=='pkg:maven/com.mycompany.myproduct/artifact-name@1.0.0'"
           }
         ]
       }

--- a/src/functionaltest/resources/responses/RulesTemplateObject.json
+++ b/src/functionaltest/resources/responses/RulesTemplateObject.json
@@ -9,7 +9,7 @@
     "MatchIdRules": {
       "_id": "%IdentifyRules_objid%"
     },
-    "ExtractionRules": "{ id : meta.id, type : meta.type, time : meta.time, gav : data.gav, fileInformation : data.fileInformation, buildCommand : data.buildCommand }",
+    "ExtractionRules": "{ id : meta.id, type : meta.type, time : meta.time, identity : data.identity, fileInformation : data.fileInformation, buildCommand : data.buildCommand }",
     "DownstreamIdentifyRules": "links | [?type=='COMPOSITION'].target",
     "DownstreamMergeRules": "{\"externalComposition\":{\"eventId\":%IdentifyRules%}}",
     "DownstreamExtractionRules": "{artifacts: [{id : meta.id}]}",

--- a/src/functionaltest/resources/responses/SubscriptionForSaveCase.json
+++ b/src/functionaltest/resources/responses/SubscriptionForSaveCase.json
@@ -1,82 +1,82 @@
-[  
-  {  
+[
+  {
     "aggregationtype":"eiffel-intelligence",
     "created":1524037895385,
     "notificationMeta":"http://eiffel-jenkins1:8080/job/ei-artifact-triggered-job/build",
     "notificationType":"REST_POST",
     "restPostBodyMediaType":"application/x-www-form-urlencoded",
-    "notificationMessageKeyValues":[  
-      {  
+    "notificationMessageKeyValues":[
+      {
         "formkey":"json",
         "formvalue":"{parameter: [{ name: 'jsonparams', value : to_string(@) }]}"
       }
     ],
     "repeat":false,
-    "requirements":[  
-      {  
-        "conditions":[  
-          {  
-            "jmespath":"gav.groupId=='com.othercompany.library'"
+    "requirements":[
+      {
+        "conditions":[
+          {
+            "jmespath":"identity=='pkg:maven/com.mycompany.myproduct/artifact-name@1.0.0'",
           }
         ]
       }
     ],
     "subscriptionName":"Subscription1",
-    "_id":{  
+    "_id":{
       "$oid":"5ad6f907c242af3f1469751d"
     }
   },
-  {  
+  {
     "aggregationtype":"eiffel-intelligence",
     "created":1524037895415,
     "notificationMeta":"http://eiffel-jenkins1:8080/job/ei-artifact-triggered-job/build",
     "notificationType":"REST_POST",
     "restPostBodyMediaType":"application/x-www-form-urlencoded",
-    "notificationMessageKeyValues":[  
-      {  
+    "notificationMessageKeyValues":[
+      {
         "formkey":"json",
         "formvalue":"{parameter: [{ name: 'jsonparams', value : to_string(@) }]}"
       }
     ],
     "repeat":false,
-    "requirements":[  
-      {  
-        "conditions":[  
-          {  
-            "jmespath":"gav.groupId=='com.othercompany.library'"
+    "requirements":[
+      {
+        "conditions":[
+          {
+            "jmespath":"identity=='pkg:maven/com.mycompany.myproduct/artifact-name@1.0.0'"
           }
         ]
       }
     ],
     "subscriptionName":"Subscription2",
-    "_id":{  
+    "_id":{
       "$oid":"5ad6f907c242af3f1469751e"
     }
   },
-  {  
+  {
     "aggregationtype":"eiffel-intelligence",
     "created":1524223397628,
     "notificationMeta":"http://<MyHost:port>/api/doit",
     "notificationType":"REST_POST",
     "restPostBodyMediaType":"application/json",
-    "notificationMessageKeyValues":[  
-      {  
+    "notificationMessageKeyValues":[
+      {
         "formkey":"",
         "formvalue":"{mydata: [{ fullaggregation : to_string(@) }]}"
       }
     ],
     "repeat":false,
-    "requirements":[  
-      {  
-        "conditions":[  
-          {  
-            "jmespath":"submission.sourceChanges[?submitter.group == 'Team Gophers' && svnIdentifier==null]"
+    "requirements":[
+      {
+        "conditions":[
+          {
+            "jmespath":"submission.sourceChanges[?submitter.group == 'Team Gophers' && gitIdentifier==null]"
           }
         ]
       }
     ],
     "subscriptionName":"Selenium_test_subscription",
-    "_id":{  
+    "_id":{
       "$oid":"5ad9cda5b715d336247e4980"
     }
   }

--- a/src/functionaltest/resources/responses/SubscriptionForUploadCase.json
+++ b/src/functionaltest/resources/responses/SubscriptionForUploadCase.json
@@ -1,113 +1,113 @@
-[  
-  {  
+[
+  {
     "aggregationtype":"eiffel-intelligence",
     "created":1524037895385,
     "userName" : "DEF",
     "notificationMeta":"http://eiffel-jenkins1:8080/job/ei-artifact-triggered-job/build",
     "notificationType":"REST_POST",
     "restPostBodyMediaType":"application/x-www-form-urlencoded",
-    "notificationMessageKeyValues":[  
-      {  
+    "notificationMessageKeyValues":[
+      {
         "formkey":"json",
         "formvalue":"{parameter: [{ name: 'jsonparams', value : to_string(@) }]}"
       }
     ],
     "repeat":false,
-    "requirements":[  
-      {  
-        "conditions":[  
-          {  
-            "jmespath":"gav.groupId=='com.othercompany.library'"
+    "requirements":[
+      {
+        "conditions":[
+          {
+            "jmespath":"identity=='pkg:maven/com.mycompany.myproduct/artifact-name@1.0.0'"
           }
         ]
       }
     ],
     "subscriptionName":"Subscription1",
-    "_id":{  
+    "_id":{
       "$oid":"5ad6f907c242af3f1469751d"
     }
   },
-  {  
+  {
     "aggregationtype":"eiffel-intelligence",
     "created":1524037895415,
     "userName" : "ABCD",
     "notificationMeta":"http://eiffel-jenkins1:8080/job/ei-artifact-triggered-job/build",
     "notificationType":"REST_POST",
     "restPostBodyMediaType":"application/x-www-form-urlencoded",
-    "notificationMessageKeyValues":[  
-      {  
+    "notificationMessageKeyValues":[
+      {
         "formkey":"json",
         "formvalue":"{parameter: [{ name: 'jsonparams', value : to_string(@) }]}"
       }
     ],
     "repeat":false,
-    "requirements":[  
-      {  
-        "conditions":[  
-          {  
-            "jmespath":"gav.groupId=='com.othercompany.library'"
+    "requirements":[
+      {
+        "conditions":[
+          {
+            "jmespath":"identity=='pkg:maven/com.mycompany.myproduct/artifact-name@1.0.0'"
           }
         ]
       }
     ],
     "subscriptionName":"Subscription2",
-    "_id":{  
+    "_id":{
       "$oid":"5ad6f907c242af3f1469751e"
     }
   },
-  {  
+  {
     "aggregationtype":"eiffel-intelligence",
     "created":1524223397628,
     "userName" : "XYZ",
     "notificationMeta":"http://<MyHost:port>/api/doit",
     "notificationType":"REST_POST",
     "restPostBodyMediaType":"application/json",
-    "notificationMessageKeyValues":[  
-      {  
+    "notificationMessageKeyValues":[
+      {
         "formkey":"",
         "formvalue":"{mydata: [{ fullaggregation : to_string(@) }]}"
       }
     ],
     "repeat":false,
-    "requirements":[  
-      {  
-        "conditions":[  
-          {  
-            "jmespath":"submission.sourceChanges[?submitter.group == 'Team Gophers' && svnIdentifier==null]"
+    "requirements":[
+      {
+        "conditions":[
+          {
+            "jmespath":"submission.sourceChanges[?submitter.group == 'Team Gophers' && gitIdentifier==null]"
           }
         ]
       }
     ],
     "subscriptionName":"Selenium_test_subscription",
-    "_id":{  
+    "_id":{
       "$oid":"5ad9cda5b715d336247e4980"
     }
   },
-  {  
+  {
     "aggregationtype":"eiffel-intelligence",
     "created":1524223397628,
     "userName" : "LMNO",
     "notificationMeta":"http://<MyHost:port>/api/doit",
     "notificationType":"REST_POST",
     "restPostBodyMediaType":"application/json",
-    "notificationMessageKeyValues":[  
-      {  
+    "notificationMessageKeyValues":[
+      {
         "formkey":"",
         "formvalue":"{mydata: [{ fullaggregation : to_string(@) }]}"
       }
     ],
     "repeat":false,
-    "requirements":[  
-      {  
-        "conditions":[  
-          {  
-            "jmespath":"submission.sourceChanges[?submitter.group == 'Team Gophers' && svnIdentifier==null]"
+    "requirements":[
+      {
+        "conditions":[
+          {
+            "jmespath":"submission.sourceChanges[?submitter.group == 'Team Gophers' && gitIdentifier==null]"
           }
         ]
       }
     ],
     "subscriptionName":"Subscription_uploaded",
-    "_id":{  
+    "_id":{
       "$oid":"5ad9cda5b715d336247e4980"
     }
   }

--- a/src/functionaltest/resources/responses/SubscriptionForUploadLDAP.json
+++ b/src/functionaltest/resources/responses/SubscriptionForUploadLDAP.json
@@ -1,88 +1,88 @@
-[  
-  {  
+[
+  {
     "aggregationtype":"eiffel-intelligence",
     "created":1524037895385,
     "ldapUserName" : "ABCD",
     "notificationMeta":"http://eiffel-jenkins1:8080/job/ei-artifact-triggered-job/build",
     "notificationType":"REST_POST",
     "restPostBodyMediaType":"application/x-www-form-urlencoded",
-    "notificationMessageKeyValues":[  
-      {  
+    "notificationMessageKeyValues":[
+      {
         "formkey":"json",
         "formvalue":"{parameter: [{ name: 'jsonparams', value : to_string(@) }]}"
       }
     ],
     "repeat":false,
-    "requirements":[  
-      {  
-        "conditions":[  
-          {  
-            "jmespath":"gav.groupId=='com.othercompany.library'"
+    "requirements":[
+      {
+        "conditions":[
+          {
+            "jmespath":"identity=='pkg:maven/com.mycompany.myproduct/artifact-name@1.0.0'"
           }
         ]
       }
     ],
     "subscriptionName":"Subscription1",
-    "_id":{  
+    "_id":{
       "$oid":"5ad6f907c242af3f1469751d"
     }
   },
-  
-  {  
+
+  {
     "aggregationtype":"eiffel-intelligence",
     "created":1524037895415,
     "ldapUserName" : "EFGH",
     "notificationMeta":"http://eiffel-jenkins1:8080/job/ei-artifact-triggered-job/build",
     "notificationType":"REST_POST",
     "restPostBodyMediaType":"application/x-www-form-urlencoded",
-    "notificationMessageKeyValues":[  
-      {  
+    "notificationMessageKeyValues":[
+      {
         "formkey":"json",
         "formvalue":"{parameter: [{ name: 'jsonparams', value : to_string(@) }]}"
       }
     ],
     "repeat":false,
-    "requirements":[  
-      {  
-        "conditions":[  
-          {  
-            "jmespath":"gav.groupId=='com.othercompany.library'"
+    "requirements":[
+      {
+        "conditions":[
+          {
+            "jmespath":"identity=='pkg:maven/com.mycompany.myproduct/artifact-name@1.0.0'"
           }
         ]
       }
     ],
     "subscriptionName":"Subscription2",
-    "_id":{  
+    "_id":{
       "$oid":"5ad6f907c242af3f1469751e"
     }
   },
-  {  
+  {
     "aggregationtype":"eiffel-intelligence",
     "created":1524223397628,
     "ldapUserName" : "ABCD",
     "notificationMeta":"http://<MyHost:port>/api/doit",
     "notificationType":"REST_POST",
     "restPostBodyMediaType":"application/json",
-    "notificationMessageKeyValues":[  
-      {  
+    "notificationMessageKeyValues":[
+      {
         "formkey":"",
         "formvalue":"{mydata: [{ fullaggregation : to_string(@) }]}"
       }
     ],
     "repeat":false,
-    "requirements":[  
-      {  
-        "conditions":[  
-          {  
-            "jmespath":"submission.sourceChanges[?submitter.group == 'Team Gophers' && svnIdentifier==null]"
+    "requirements":[
+      {
+        "conditions":[
+          {
+            "jmespath":"submission.sourceChanges[?submitter.group == 'Team Gophers' && gitIdentifier==null]"
           }
         ]
       }
     ],
     "subscriptionName":"Subscription3",
-    "_id":{  
+    "_id":{
       "$oid":"5ad9cda5b715d336247e4980"
     }
   }
-  
+
 ]

--- a/src/functionaltest/resources/responses/SubscriptionObjects.json
+++ b/src/functionaltest/resources/responses/SubscriptionObjects.json
@@ -1,82 +1,82 @@
-[  
-  {  
+[
+  {
     "aggregationtype":"eiffel-intelligence",
     "created":1524037895385,
     "notificationMeta":"http://eiffel-jenkins1:8080/job/ei-artifact-triggered-job/build",
     "notificationType":"REST_POST",
     "restPostBodyMediaType":"application/x-www-form-urlencoded",
-    "notificationMessageKeyValues":[  
-      {  
+    "notificationMessageKeyValues":[
+      {
         "formkey":"json",
         "formvalue":"{parameter: [{ name: 'jsonparams', value : to_string(@) }]}"
       }
     ],
     "repeat":false,
-    "requirements":[  
-      {  
-        "conditions":[  
-          {  
-            "jmespath":"gav.groupId=='com.othercompany.library'"
+    "requirements":[
+      {
+        "conditions":[
+          {
+            "jmespath":"identity=='pkg:maven/com.mycompany.myproduct/artifact-name@1.0.0'"
           }
         ]
       }
     ],
     "subscriptionName":"Subscription1",
-    "_id":{  
+    "_id":{
       "$oid":"5ad6f907c242af3f1469751d"
     }
   },
-  {  
+  {
     "aggregationtype":"eiffel-intelligence",
     "created":1524037895415,
     "notificationMeta":"http://eiffel-jenkins1:8080/job/ei-artifact-triggered-job/build",
     "notificationType":"REST_POST",
     "restPostBodyMediaType":"application/x-www-form-urlencoded",
-    "notificationMessageKeyValues":[  
-      {  
+    "notificationMessageKeyValues":[
+      {
         "formkey":"json",
         "formvalue":"{parameter: [{ name: 'jsonparams', value : to_string(@) }]}"
       }
     ],
     "repeat":false,
-    "requirements":[  
-      {  
-        "conditions":[  
-          {  
-            "jmespath":"gav.groupId=='com.othercompany.library'"
+    "requirements":[
+      {
+        "conditions":[
+          {
+            "jmespath":"identity=='pkg:maven/com.mycompany.myproduct/artifact-name@1.0.0'"
           }
         ]
       }
     ],
     "subscriptionName":"Subscription2",
-    "_id":{  
+    "_id":{
       "$oid":"5ad6f907c242af3f1469751e"
     }
   },
-  {  
+  {
     "aggregationtype":"eiffel-intelligence",
     "created":1524223397628,
     "notificationMeta":"http://<MyHost:port>/api/doit",
     "notificationType":"REST_POST",
     "restPostBodyMediaType":"application/json",
-    "notificationMessageKeyValues":[  
-      {  
+    "notificationMessageKeyValues":[
+      {
         "formkey":"",
         "formvalue":"{mydata: [{ fullaggregation : to_string(@) }]}"
       }
     ],
     "repeat":false,
-    "requirements":[  
-      {  
-        "conditions":[  
-          {  
-            "jmespath":"submission.sourceChanges[?submitter.group == 'Team Gophers' && svnIdentifier==null]"
+    "requirements":[
+      {
+        "conditions":[
+          {
+            "jmespath":"submission.sourceChanges[?submitter.group == 'Team Gophers' && gitIdentifier==null]"
           }
         ]
       }
     ],
     "subscriptionName":"Subscription_Template_Rest_Post_Raw_Body_Json_Trigger",
-    "_id":{  
+    "_id":{
       "$oid":"5ad9cda5b715d336247e4980"
     }
   }

--- a/src/functionaltest/resources/responses/SubscriptionTemplate.json
+++ b/src/functionaltest/resources/responses/SubscriptionTemplate.json
@@ -1,109 +1,109 @@
-[  
-  {  
+[
+  {
     "aggregationtype":"eiffel-intelligence",
     "created":1524037895385,
     "notificationMeta":"http://eiffel-jenkins1:8080/job/ei-artifact-triggered-job/build",
     "notificationType":"REST_POST",
     "restPostBodyMediaType":"application/x-www-form-urlencoded",
-    "notificationMessageKeyValues":[  
-      {  
+    "notificationMessageKeyValues":[
+      {
         "formkey":"json",
         "formvalue":"{parameter: [{ name: 'jsonparams', value : to_string(@) }]}"
       }
     ],
     "repeat":false,
-    "requirements":[  
-      {  
-        "conditions":[  
-          {  
-            "jmespath":"gav.groupId=='com.othercompany.library'"
+    "requirements":[
+      {
+        "conditions":[
+          {
+            "jmespath":"identity=='pkg:maven/com.mycompany.myproduct/artifact-name@1.0.0'"
           }
         ]
       }
     ],
     "subscriptionName":"Subscription1",
-    "_id":{  
+    "_id":{
       "$oid":"5ad6f907c242af3f1469751d"
     }
   },
-  {  
+  {
     "aggregationtype":"eiffel-intelligence",
     "created":1524037895415,
     "notificationMeta":"http://eiffel-jenkins1:8080/job/ei-artifact-triggered-job/build",
     "notificationType":"REST_POST",
     "restPostBodyMediaType":"application/x-www-form-urlencoded",
-    "notificationMessageKeyValues":[  
-      {  
+    "notificationMessageKeyValues":[
+      {
         "formkey":"json",
         "formvalue":"{parameter: [{ name: 'jsonparams', value : to_string(@) }]}"
       }
     ],
     "repeat":false,
-    "requirements":[  
-      {  
-        "conditions":[  
-          {  
-            "jmespath":"gav.groupId=='com.othercompany.library'"
+    "requirements":[
+      {
+        "conditions":[
+          {
+            "jmespath":"identity=='pkg:maven/com.mycompany.myproduct/artifact-name@1.0.0'"
           }
         ]
       }
     ],
     "subscriptionName":"Subscription2",
-    "_id":{  
+    "_id":{
       "$oid":"5ad6f907c242af3f1469751e"
     }
   },
-  {  
+  {
     "aggregationtype":"eiffel-intelligence",
     "created":1524223397628,
     "notificationMeta":"http://<MyHost:port>/api/doit",
     "notificationType":"REST_POST",
     "restPostBodyMediaType":"application/json",
-    "notificationMessageKeyValues":[  
-      {  
+    "notificationMessageKeyValues":[
+      {
         "formkey":"",
         "formvalue":"{mydata: [{ fullaggregation : to_string(@) }]}"
       }
     ],
     "repeat":false,
-    "requirements":[  
-      {  
-        "conditions":[  
-          {  
-            "jmespath":"submission.sourceChanges[?submitter.group == 'Team Gophers' && svnIdentifier==null]"
+    "requirements":[
+      {
+        "conditions":[
+          {
+            "jmespath":"submission.sourceChanges[?submitter.group == 'Team Gophers' && gitIdentifier==null]"
           }
         ]
       }
     ],
     "subscriptionName":"Selenium_test_subscription",
-    "_id":{  
+    "_id":{
       "$oid":"5ad9cda5b715d336247e4980"
     }
   },
-  {  
+  {
     "aggregationtype":"eiffel-intelligence",
     "created":1524223397628,
     "notificationMeta":"http://<MyHost:port>/api/doit",
     "notificationType":"REST_POST",
     "restPostBodyMediaType":"application/json",
-    "notificationMessageKeyValues":[  
-      {  
+    "notificationMessageKeyValues":[
+      {
         "formkey":"",
         "formvalue":"{mydata: [{ fullaggregation : to_string(@) }]}"
       }
     ],
     "repeat":false,
-    "requirements":[  
-      {  
-        "conditions":[  
-          {  
-            "jmespath":"submission.sourceChanges[?submitter.group == 'Team Gophers' && svnIdentifier==null]"
+    "requirements":[
+      {
+        "conditions":[
+          {
+            "jmespath":"submission.sourceChanges[?submitter.group == 'Team Gophers' && gitIdentifier==null]"
           }
         ]
       }
     ],
     "subscriptionName":"Subscription_uploaded",
-    "_id":{  
+    "_id":{
       "$oid":"5ad9cda5b715d336247e4980"
     }
   }

--- a/src/functionaltest/resources/responses/SubscriptionUpload.json
+++ b/src/functionaltest/resources/responses/SubscriptionUpload.json
@@ -17,7 +17,7 @@
       "type": "ARTIFACT_1",
       "conditions": [
         {
-          "jmespath": "gav.groupId=='com.mycompany.myproduct'"
+          "jmespath": "identity=='pkg:maven/com.mycompany.myproduct/artifact-name@1.0.0'"
         },
         {
           "jmespath": "testCaseExecutions[?testCase.conclusion == 'SUCCESSFUL' && testCase.id=='TC5']"
@@ -28,7 +28,7 @@
       "type": "ARTIFACT_1",
       "conditions": [
         {
-          "jmespath": "gav.groupId=='com.mycompany.myproduct'"
+          "jmespath": "identity=='pkg:maven/com.mycompany.myproduct/artifact-name@1.0.0'"
         },
         {
           "jmespath": "testCaseExecutions[?testCaseStartedEventId == '13af4a14-f951-4346-a1ba-624c79f10e98']"

--- a/src/functionaltest/resources/responses/subscription.json
+++ b/src/functionaltest/resources/responses/subscription.json
@@ -17,7 +17,7 @@
         "type": "ARTIFACT_1",
         "conditions": [
           {
-            "jmespath": "gav.groupId=='com.mycompany.myproduct'"
+            "jmespath": "identity=='pkg:maven/com.mycompany.myproduct/artifact-name@1.0.0'"
           },
           {
             "jmespath": "testCaseExecutions[?testCase.conclusion == 'SUCCESSFUL' && testCase.id=='TC5']"
@@ -28,7 +28,7 @@
         "type": "ARTIFACT_1",
         "conditions": [
           {
-            "jmespath": "gav.groupId=='com.mycompany.myproduct'"
+            "jmespath": "identity=='pkg:maven/com.mycompany.myproduct/artifact-name@1.0.0'"
           },
           {
             "jmespath": "testCaseExecutions[?testCaseStartedEventId == '13af4a14-f951-4346-a1ba-624c79f10e98']"

--- a/src/integrationtest/resources/bodies/listEvents.json
+++ b/src/integrationtest/resources/bodies/listEvents.json
@@ -3,18 +3,14 @@
         "meta": {
             "id": "df4cdb42-1580-4cff-b97a-4d0faa9b2b22",
             "type": "EiffelArtifactCreatedEvent",
-            "version": "1.1.0",
+            "version": "3.0.0",
             "time": 1521452368194,
             "tags": [],
             "source": {
                 "domainId": "eiffel039.seli.fem101",
                 "host": "eselivm2v1464l",
                 "name": "fem101-eiffel039",
-                "serializer": {
-                    "groupId": "com.github.Ericsson",
-                    "artifactId": "eiffel-remrem-semantics",
-                    "version": "0.0.10"
-                },
+                "serializer": "pkg:maven/com.mycompany.tools/eiffel-serializer@1.0.3",
                 "uri": "https://arm101-eiffel039.lmera.ericsson.se:8443/nexus/content/repositories/releases"
             },
             "security": {
@@ -25,11 +21,7 @@
             }
         },
         "data": {
-            "gav": {
-                "groupId": "com.ericsson.eiffel",
-                "artifactId": "eiffel-dummy-component-1",
-                "version": "0.0.48-SNAPSHOT"
-            },
+            "identity": "pkg:maven/com.mycompany.myproduct/artifact-name@2.0.0",
             "fileInformation": [
                 {
                     "classifier": "",
@@ -38,13 +30,7 @@
             ],
             "buildCommand": "trigger",
             "requiresImplementation": "NONE",
-            "dependsOn": [
-                {
-                    "groupId": "",
-                    "artifactId": "",
-                    "version": ""
-                }
-            ],
+            "dependsOn": ["pkg:maven/com.mycompany.myproduct/my-interface@%5B1.0%2C2.0%29"],
             "implements": [],
             "name": "event",
             "customData": []
@@ -60,18 +46,14 @@
         "meta": {
             "id": "e3be0cf8-2ebd-4d6d-bf5c-a3b535cd084e",
             "type": "EiffelConfidenceLevelModifiedEvent",
-            "version": "1.1.0",
+            "version": "3.0.0",
             "time": 1521452400324,
             "tags": [],
             "source": {
                 "domainId": "eiffel039.seli.fem101",
                 "host": "eselivm2v1464l",
                 "name": "fem101-eiffel039",
-                "serializer": {
-                    "groupId": "com.github.Ericsson",
-                    "artifactId": "eiffel-remrem-semantics",
-                    "version": "0.0.10"
-                },
+                "serializer": "pkg:maven/com.mycompany.tools/eiffel-serializer@1.0.3",
                 "uri": ""
             },
             "security": {
@@ -103,17 +85,13 @@
         "meta": {
             "id": "2acd348d-05e6-4945-b441-dc7c1e55534e",
             "type": "EiffelArtifactPublishedEvent",
-            "version": "1.1.0",
+            "version": "3.0.0",
             "time": 1521452368758,
             "tags": [],
             "source": {
                 "domainId": "eiffel039.seli.fem101",
                 "name": "fem101-eiffel039",
-                "serializer": {
-                    "groupId": "com.github.Ericsson",
-                    "artifactId": "eiffel-remrem-semantics",
-                    "version": "0.0.10"
-                }
+                "serializer": "pkg:maven/com.mycompany.tools/eiffel-serializer@1.0.3"
             }
         },
         "data": {

--- a/src/integrationtest/resources/bodies/listRules.json
+++ b/src/integrationtest/resources/bodies/listRules.json
@@ -9,7 +9,7 @@
         "MatchIdRules": {
             "_id": "%IdentifyRules_objid%"
         },
-        "ExtractionRules": "{ id : meta.id, type : meta.type, time : meta.time, gav : data.gav, fileInformation : data.fileInformation, buildCommand : data.buildCommand }",
+        "ExtractionRules": "{ id : meta.id, type : meta.type, time : meta.time, identity : data.identity, fileInformation : data.fileInformation, buildCommand : data.buildCommand }",
         "DownstreamIdentifyRules": "links | [?type=='COMPOSITION'].target",
         "DownstreamMergeRules": "{\"externalComposition\":{\"eventId\":%IdentifyRules%}}",
         "DownstreamExtractionRules": "{artifacts: [{id : meta.id}]}",

--- a/src/integrationtest/resources/bodies/queryFreestyle.json
+++ b/src/integrationtest/resources/bodies/queryFreestyle.json
@@ -1,5 +1,5 @@
 {
   "criteria": {
-    "object.gav.groupId": "com.mycompany.myproduct"
+    "aggregatedObject.identity": "pkg:maven/com.mycompany.myproduct/artifact-name@2.0.0"
   }
 }

--- a/src/integrationtest/resources/bodies/subscription_single.json
+++ b/src/integrationtest/resources/bodies/subscription_single.json
@@ -15,7 +15,7 @@
       {
         "conditions": [
           {
-            "jmespath": "gav.groupId=='com.mycompany.myproduct'"
+            "jmespath": "identity=='pkg:maven/com.mycompany.myproduct/artifact-name@2.0.0'"
           },
           {
             "jmespath": "testCaseExecutions[?testCase.conclusion == 'SUCCESSFUL' && testCase.id=='TC5']"
@@ -26,7 +26,7 @@
       {
         "conditions": [
           {
-            "jmespath": "gav.groupId=='com.mycompany.myproduct'"
+            "jmespath": "identity=='pkg:maven/com.mycompany.myproduct/artifact-name@2.0.0'"
           },
           {
             "jmespath": "testCaseExecutions[?testCaseStartedEventId == '13af4a14-f951-4346-a1ba-624c79f10e98']"

--- a/src/integrationtest/resources/bodies/subscription_single_modify.json
+++ b/src/integrationtest/resources/bodies/subscription_single_modify.json
@@ -15,7 +15,7 @@
       {
         "conditions": [
           {
-            "jmespath": "gav.groupId=='com.mycompany.myproduct'"
+            "jmespath": "identity=='pkg:maven/com.mycompany.myproduct/artifact-name@2.0.0'"
           },
           {
             "jmespath": "testCaseExecutions[?testCase.conclusion == 'SUCCESSFUL' && testCase.id=='TC5']"
@@ -26,7 +26,7 @@
       {
         "conditions": [
           {
-            "jmespath": "gav.groupId=='com.mycompany.myproduct'"
+            "jmespath": "identity=='pkg:maven/com.mycompany.myproduct/artifact-name@2.0.0'"
           },
           {
             "jmespath": "testCaseExecutions[?testCaseStartedEventId == '13af4a14-f951-4346-a1ba-624c79f10e98']"

--- a/src/integrationtest/resources/eiffel_event.json
+++ b/src/integrationtest/resources/eiffel_event.json
@@ -1,60 +1,56 @@
 {
-	"meta": {
-		"id": "6acc3c87-75e0-4b6d-88f5-b1a5d4e62b43",
-		"source": {
-			"domainId": "example.domain"
-		},
-		"time": 1481875891763,
-		"type": "EiffelArtifactCreatedEvent",
-		"version": "1.0.0"
-	},
-	"data": {
-		"customData": [
-			{
-				"value": "ArtC2",
-				"key": "name"
-			},
-			{
-				"value": 1,
-				"key": "iteration"
-			}
-		],
-		"fileInformation": [
-			{
-				"classifier": "debug",
-				"extension": "jar"
-			},
-			{
-				"classifier": "test",
-				"extension": "txt"
-			},
-			{
-				"classifier": "application",
-				"extension": "exe"
-			}
-		],
-		"gav": {
-			"artifactId": "sub-system",
-			"version": "1.1.0",
-			"groupId": "com.mycompany.myproduct"
-		}
-	},
-	"links": [
-		{
-			"target": "fb6ef12d-25fb-4d77-b9fd-87688e66de47",
-			"type": "COMPOSITION"
-		},
-		{
-			"target": "1100572b-c3j4-441e-abc9-b62f48080011",
-			"type": "PREVIOUS_VERSION"
-		},
-		{
-			"target": "c4f9565d-2382-488f-b911-e3326bce21a3",
-			"type": "ENVIRONMENT"
-		},
-		{
-			"target": "c04fa59a-3c36-4601-8eac-7a26b8910f08",
-			"type": "CONTEXT"
-		}
-	]
+  "meta": {
+    "id": "6acc3c87-75e0-4b6d-88f5-b1a5d4e62b43",
+    "source": {
+      "domainId": "example.domain"
+    },
+    "time": 1481875891763,
+    "type": "EiffelArtifactCreatedEvent",
+    "version": "3.0.0"
+  },
+  "data": {
+    "customData": [
+      {
+        "value": "ArtC2",
+        "key": "name"
+      },
+      {
+        "value": 1,
+        "key": "iteration"
+      }
+    ],
+    "fileInformation": [
+      {
+        "classifier": "debug",
+        "extension": "jar"
+      },
+      {
+        "classifier": "test",
+        "extension": "txt"
+      },
+      {
+        "classifier": "application",
+        "extension": "exe"
+      }
+    ],
+    "identity": "pkg:maven/com.mycompany.myproduct/artifact-name@2.0.0"
+  },
+  "links": [
+    {
+      "target": "fb6ef12d-25fb-4d77-b9fd-87688e66de47",
+      "type": "COMPOSITION"
+    },
+    {
+      "target": "1100572b-c3j4-441e-abc9-b62f48080011",
+      "type": "PREVIOUS_VERSION"
+    },
+    {
+      "target": "c4f9565d-2382-488f-b911-e3326bce21a3",
+      "type": "ENVIRONMENT"
+    },
+    {
+      "target": "c04fa59a-3c36-4601-8eac-7a26b8910f08",
+      "type": "CONTEXT"
+    }
+  ]
 }

--- a/src/integrationtest/resources/responses/rulesAggregation.json
+++ b/src/integrationtest/resources/responses/rulesAggregation.json
@@ -9,6 +9,7 @@
                 }
             ],
             "buildCommand": "trigger",
+            "identity": "pkg:maven/com.mycompany.myproduct/artifact-name@2.0.0",
             "confidenceLevels": [
                 {
                     "eventId": "e3be0cf8-2ebd-4d6d-bf5c-a3b535cd084e_ARTIFACT_TEST",
@@ -21,11 +22,6 @@
             "id": "df4cdb42-1580-4cff-b97a-4d0faa9b2b22_ARTIFACT_TEST",
             "time": 1521452368194,
             "type": "EiffelArtifactCreatedEvent",
-            "gav": {
-                "groupId": "com.ericsson.eiffel",
-                "artifactId": "eiffel-dummy-component-1",
-                "version": "0.0.48-SNAPSHOT"
-            },
             "publications": [
                 {
                     "eventId": "2acd348d-05e6-4945-b441-dc7c1e55534e_ARTIFACT_TEST",

--- a/src/test/resources/backendResponses/downloadRulesTemplateResponse.json
+++ b/src/test/resources/backendResponses/downloadRulesTemplateResponse.json
@@ -7,7 +7,7 @@
         "StartEvent": "YES",
         "IdentifyRules": "[meta.id]",
         "MatchIdRules": {"_id": "%IdentifyRules_objid%"},
-        "ExtractionRules": "{ id : meta.id, type : meta.type, time : meta.time, gav : data.gav, fileInformation : data.fileInformation, buildCommand : data.buildCommand }",
+        "ExtractionRules": "{ id : meta.id, type : meta.type, time : meta.time, identity : data.identity, fileInformation : data.fileInformation, buildCommand : data.buildCommand }",
         "DownstreamIdentifyRules": "links | [?type=='COMPOSITION'].target",
         "DownstreamMergeRules": "{\"externalComposition\":{\"eventId\":%IdentifyRules%}}",
         "DownstreamExtractionRules": "{artifacts: [{id : meta.id}]}",

--- a/src/test/resources/backendResponses/subscriptionsOneResponse.json
+++ b/src/test/resources/backendResponses/subscriptionsOneResponse.json
@@ -15,7 +15,7 @@
         {
             "type": "ARTIFACT_1",
             "conditions": [
-                {"jmespath": "gav.groupId=='com.mycompany.myproduct'"},
+                {"jmespath": "identity=='pkg:maven/com.mycompany.myproduct/artifact-name@3.0.0'"},
                 {"jmespath": "testCaseExecutions[?testCase.conclusion == 'SUCCESSFUL' && testCase.id=='TC5']"}
             ]
 
@@ -23,7 +23,7 @@
         {
             "type": "ARTIFACT_1",
             "conditions": [
-                {"jmespath": "gav.groupId=='com.mycompany.myproduct'"},
+                {"jmespath": "identity=='pkg:maven/com.mycompany.myproduct/artifact-name@3.0.0'"},
                 {"jmespath": "testCaseExecutions[?testCaseStartedEventId == '13af4a14-f951-4346-a1ba-624c79f10e98']"}
             ]
 

--- a/src/test/resources/backendResponses/subscriptionsResponse.json
+++ b/src/test/resources/backendResponses/subscriptionsResponse.json
@@ -15,7 +15,7 @@
             {
                 "conditions": [
                     {
-                        "jmespath": "submission.sourceChanges[?submitter.group == 'Team Gophers' && svnIdentifier==null]"
+                        "jmespath": "submission.sourceChanges[?submitter.group == 'Team Gophers' && gitIdentifier==null]"
                     }
                 ]
             }
@@ -43,7 +43,7 @@
             {
                 "conditions": [
                     {
-                        "jmespath": "submission.sourceChanges[?submitter.group == 'Team Gophers' && svnIdentifier==null]"
+                        "jmespath": "submission.sourceChanges[?submitter.group == 'Team Gophers' && gitIdentifier==null]"
                     }
                 ]
             }
@@ -71,7 +71,7 @@
             {
                 "conditions": [
                     {
-                        "jmespath": "submission.sourceChanges[?submitter.group == 'Team Gophers' && svnIdentifier==null]"
+                        "jmespath": "submission.sourceChanges[?submitter.group == 'Team Gophers' && gitIdentifier==null]"
                     }
                 ]
             }


### PR DESCRIPTION
### Applicable Issues
EI frontend needed to be updated to follow Agen edition of Eiffel protocol.

### Description of the Change
Mostly test resources have been updated to match the new syntax. Made sure all unit tests, functional tests and integration tests follow the new protocol as they serve as a form of documentation.
* Subscriptions no longer references any gav in conditions.
* Eiffel events are uplifted to version 3.0.0 and gav is removed and instead data.identity is used in relevant events.
* Aggregated objects are updated according to new structure.


### Benefits
If the test resources are updated to use latest, besides improving testing functionality it can also serve as documentation purpose.


### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Emelie Pettersson emelie.pettersson@ericsson.com
