### PR TITLE
Add status links to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@
 
 <img src="./images/eiffel-intelligence-logo.png" alt="Eiffel Intelligence" width="350"/>
 
+[![Build Status](https://travis-ci.org/eiffel-community/eiffel-intelligence-frontend.svg?branch=master)](https://travis-ci.org/eiffel-community/eiffel-intelligence-frontend)
+[![Coverage Status](https://coveralls.io/repos/github/eiffel-community/eiffel-intelligence-frontend/badge.svg?branch=master)](https://coveralls.io/github/eiffel-community/eiffel-intelligence-frontend?branch=master)
+[![](https://jitpack.io/v/eiffel-community/eiffel-intelligence-frontend.svg)](https://jitpack.io/#eiffel-community/eiffel-intelligence-frontend)
+
+
 # Eiffel Intelligence Frontend
 Eiffel Intelligence Frontend is part of the [Eiffel Intelligence](https://github.com/eiffel-community/eiffel-intelligence) implementation of the [Eiffel Protocol](https://github.com/eiffel-community/eiffel). Eiffel Intelligence Frontend allows the configuration of subscription and aggregation rules in Eiffel Intelligence.
 


### PR DESCRIPTION
### Applicable Issues
There was no link to EI frontend Travis tests or Jitpack, which exists in EI backend.

### Description of the Change
Added links to Travis, coverage and jitpack. Note that coveralls is not currently enabled for either EI backend or EI frontend.

### Alternate Designs
None.

### Benefits
Easier access to Jitpack for fetching releases or Travis to see status of latest builds.

### Possible Drawbacks
None.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Emelie Pettersson emelie.pettersson@ericsson.com
