### PR TITLE
Add jenkins internal and exteranl url

### DIFF
--- a/src/systemtest/java/com/ericsson/ei/systemtest/artifactflow/ArtifactFlowSteps.java
+++ b/src/systemtest/java/com/ericsson/ei/systemtest/artifactflow/ArtifactFlowSteps.java
@@ -37,7 +37,7 @@ public class ArtifactFlowSteps extends AbstractTestExecutionListener {
     @Given("^subscription object \"([^\"]*)\" is created which will trigger \"([^\"]*)\"(.*)$")
     public void subscription_is_created(String subscriptionName, String nameOfTriggeredJob, String hasParameters) throws Throwable {
         StepsUtils.createSubscription(subscriptionName, nameOfTriggeredJob, config.getJenkinsUsername(), config.getJenkinsPassword(),
-                                      config.getJenkinsBaseUrl(), !hasParameters.isEmpty());
+                                      config.getJenkinsInternalBaseUrl(), !hasParameters.isEmpty());
     }
 
     @Given("^the jenkins job \"([^\"]*)\" is triggered$")
@@ -60,7 +60,7 @@ public class ArtifactFlowSteps extends AbstractTestExecutionListener {
         boolean success = StepsUtils.createJenkinsJob(
                 jenkinsJobName,
                 scriptFileName,
-                config.getJenkinsBaseUrl(),
+                config.getJenkinsExternalBaseUrl(),
                 config.getJenkinsUsername(),
                 config.getJenkinsPassword(),
                 config.getRemremBaseUrl(),

--- a/src/systemtest/java/com/ericsson/ei/systemtest/sourcechangeflow/SourceChangeFlowSteps.java
+++ b/src/systemtest/java/com/ericsson/ei/systemtest/sourcechangeflow/SourceChangeFlowSteps.java
@@ -40,7 +40,7 @@ public class SourceChangeFlowSteps extends AbstractTestExecutionListener {
         boolean success = StepsUtils.createJenkinsJob(
                 jenkinsJobName,
                 scriptFileName,
-                config.getJenkinsBaseUrl(),
+                config.getJenkinsExternalBaseUrl(),
                 config.getJenkinsUsername(),
                 config.getJenkinsPassword(),
                 config.getRemremBaseUrl(),
@@ -63,7 +63,7 @@ public class SourceChangeFlowSteps extends AbstractTestExecutionListener {
     @Given("^subscription object \"([^\"]*)\" is created which will trigger \"([^\"]*)\"(.*)$")
     public void subscription_is_created(String subscriptionName, String nameOfTriggeredJob, String hasParameters) throws Throwable {
         StepsUtils.createSubscription(subscriptionName, nameOfTriggeredJob, config.getJenkinsUsername(), config.getJenkinsPassword(),
-                config.getJenkinsBaseUrl(), !hasParameters.isEmpty());
+                config.getJenkinsInternalBaseUrl(), !hasParameters.isEmpty());
     }
 
     @When("^notification with key \"([^\"]*)\" and value \"([^\"]*)\" is added to \"([^\"]*)\"$")

--- a/src/systemtest/java/com/ericsson/ei/systemtest/testexecutionflow/TestExecutionFlowSteps.java
+++ b/src/systemtest/java/com/ericsson/ei/systemtest/testexecutionflow/TestExecutionFlowSteps.java
@@ -37,7 +37,7 @@ public class TestExecutionFlowSteps extends AbstractTestExecutionListener {
     @Given("^subscription object \"([^\"]*)\" is created which will trigger \"([^\"]*)\"(.*)$")
     public void subscription_is_created(String subscriptionName, String nameOfTriggeredJob, String hasParameters) throws Throwable {
         StepsUtils.createSubscription(subscriptionName, nameOfTriggeredJob, config.getJenkinsUsername(), config.getJenkinsPassword(),
-                                      config.getJenkinsBaseUrl(), !hasParameters.isEmpty());
+                                      config.getJenkinsInternalBaseUrl(), !hasParameters.isEmpty());
     }
 
     @Given("^the jenkins job \"([^\"]*)\" is triggered$")
@@ -60,7 +60,7 @@ public class TestExecutionFlowSteps extends AbstractTestExecutionListener {
         boolean success = StepsUtils.createJenkinsJob(
                 jenkinsJobName,
                 scriptFileName,
-                config.getJenkinsBaseUrl(),
+                config.getJenkinsExternalBaseUrl(),
                 config.getJenkinsUsername(),
                 config.getJenkinsPassword(),
                 config.getRemremBaseUrl(),

--- a/src/systemtest/java/com/ericsson/ei/systemtest/utils/Config.java
+++ b/src/systemtest/java/com/ericsson/ei/systemtest/utils/Config.java
@@ -7,7 +7,8 @@ import lombok.Getter;
 @Getter
 public class Config {
 
-    private String jenkinsBaseUrl;
+    private String jenkinsExternalBaseUrl;
+    private String jenkinsInternalBaseUrl;
     private String jenkinsUsername;
     private String jenkinsPassword;
 
@@ -37,11 +38,13 @@ public class Config {
     * @return
     */
     public void initJenkinsConfig() {
-        jenkinsBaseUrl = System.getProperty("jenkins.url");
+        jenkinsExternalBaseUrl = System.getProperty("jenkins.external.url");
+        jenkinsInternalBaseUrl = System.getProperty("jenkins.internal.url");
         jenkinsUsername = System.getProperty("jenkins.username");
         jenkinsPassword = System.getProperty("jenkins.password");
 
-        assertNotNull(jenkinsBaseUrl);
+        assertNotNull(jenkinsExternalBaseUrl);
+        assertNotNull(jenkinsInternalBaseUrl);
         assertNotNull(jenkinsUsername);
         assertNotNull(jenkinsPassword);
     }

--- a/src/systemtest/resources/system-test.properties
+++ b/src/systemtest/resources/system-test.properties
@@ -4,18 +4,19 @@ application.name=eiffel-intelligence
 logging.level: INFO
 
 ######## EI Front-End
-ei.frontend.url:http://localhost:8077
+ei.frontend.url:http://localhost:8081
 
 ######## EI Back-End
-ei.backend.url.artifact:http://localhost:8070
-ei.backend.url.sourcechange:http://localhost:8072
-ei.backend.url.testexecution:http://localhost:8074
+ei.backend.url.artifact:http://ei-backend-artifact:8080
+ei.backend.url.sourcechange:http://ei-backend-sourcechange:8080
+ei.backend.url.testexecution:http://ei-backend-testexecution:8080
 
 ######## Remrem-Publish
-remrem.publish.url:http://localhost:8096
+remrem.publish.url:http://publish:8080
 
 
 ## # Jenkins configuration
-jenkins.url:http://localhost:8082
+jenkins.external.url:http://localhost:8082
+jenkins.internal.url:http://jenkins:8080
 jenkins.username: admin
 jenkins.password: admin


### PR DESCRIPTION
### Applicable Issues
Systemtests won't work without having two properties for jenkins url. External url to create jobs and internal url when ei-frontend triggers jobs.

### Description of the Change

### Alternate Designs

### Benefits

### Possible Drawbacks

### Sign-off
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: christoffer.cortes.sjowall@ericsson.com
