### PR TITLE
Use LDAP container for IT tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ before_install:
   - export JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64
   - java -version
   - source src/main/docker/env.bash
-  - docker-compose -f src/main/docker/docker-compose.yml up -d eiffel-er mongodb rabbitmq jenkins mail-server
+  - docker-compose -f src/main/docker/docker-compose.yml up -d eiffel-er mongodb rabbitmq jenkins mail-server ldap ldap-seed
 
 
 install:

--- a/src/integrationtest/resources/integration-test.properties
+++ b/src/integrationtest/resources/integration-test.properties
@@ -122,11 +122,11 @@ er.url:
 #er.url: http://localhost:8080/eventrepository/search/
 # settings for ldap server if ldap authentication is needed
 ldap.enabled: true
-ldap.url: ldap://ldap.forumsys.com:389/dc=example,dc=com
+ldap.url: ldap://localhost:389/dc=example,dc=org
 ldap.base.dn:
-ldap.username: cn=read-only-admin,dc=example,dc=com
+ldap.username: cn=admin,dc=example,dc=org
 # For security reasons and to avoid authorization problems this
 # password should be encoded. It will be decoded in EndpointSecurity.java.
 # Password needs to be encoded with base64.
-ldap.password: cGFzc3dvcmQ=
+ldap.password: YWRtaW4=
 ldap.user.filter: uid={0}

--- a/src/main/docker/docker-compose.yml
+++ b/src/main/docker/docker-compose.yml
@@ -389,5 +389,31 @@ services:
       - logging.level.org.springframework.web=DEBUG
       - logging.level.com.ericsson.ei=DEBUG
 
+  ldap:
+    restart: always
+    image: osixia/openldap
+    hostname: "example.org"
+    expose:
+      - "389"
+      - "636"
+    ports:
+      - "389:389"
+      - "636:636"
+    environment:
+        LDAP_TLS: 'false'
+        LDAP_ORGANISATION: "Test"
+        LDAP_DOMAIN: "example.org"
+        LDAP_BASE_DN: "dc=example,dc=org"
+        LDAP_ADMIN_PASSWORD: "admin"
+
+  ldap-seed:
+    image: osixia/openldap
+    volumes:
+      - ./ldap-seed:/container/service/slapd/assets/test/
+    links:
+      - ldap
+    command: chmod +x /container/service/slapd/assets/test/addAll.sh
+    entrypoint: sh -c '/container/service/slapd/assets/test/addAll.sh'
+
 networks:
   eiffel_2.0_1:

--- a/src/main/docker/ldap-seed/addAll.sh
+++ b/src/main/docker/ldap-seed/addAll.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+sleep 5
+ldapadd -h ldap -D "cn=admin,dc=example,dc=org" -w admin -f /container/service/slapd/assets/test/gauss.ldif
+ldapadd -h ldap -D "cn=admin,dc=example,dc=org" -w admin -f /container/service/slapd/assets/test/newton.ldif

--- a/src/main/docker/ldap-seed/gauss.ldif
+++ b/src/main/docker/ldap-seed/gauss.ldif
@@ -1,0 +1,14 @@
+dn: uid=gauss,dc=example,dc=org
+uid: gauss
+cn: gauss
+sn: 3
+objectClass: top
+objectClass: posixAccount
+objectClass: inetOrgPerson
+loginShell: /bin/bash
+homeDirectory: /home/gauss
+uidNumber: 14583102
+gidNumber: 14564100
+userPassword: password
+mail: gauss@example.org
+gecos: Gauss User

--- a/src/main/docker/ldap-seed/newton.ldif
+++ b/src/main/docker/ldap-seed/newton.ldif
@@ -1,0 +1,14 @@
+dn: uid=newton,dc=example,dc=org
+uid: newton
+cn: newton
+sn: 3
+objectClass: top
+objectClass: posixAccount
+objectClass: inetOrgPerson
+loginShell: /bin/bash
+homeDirectory: /home/newton
+uidNumber: 14583103
+gidNumber: 14564101
+userPassword: password
+mail: newton@example.org
+gecos: Newton User


### PR DESCRIPTION
### Applicable Issues
Integration tests will fail at times when forumsys are having downtime or otherwise doing changes on their ldap server.

### Description of the Change
Instead of using forumsys ldap server we can now set up our own ldap server in a container.

### Alternate Designs

### Benefits

### Possible Drawbacks

### Sign-off
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Christoffer Cortes Sjöwall, christoffer.cortes.sjowall@ericsson.com
