### PR TITLE
Show JSON information inside pre blocks with pretty format

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ before_install:
   - |
     if [[ $TRAVIS_JOB_NAME = integrationTests ]]; then
       source src/main/docker/env.bash
-      docker-compose -f src/main/docker/docker-compose.yml up -d eiffel-er mongodb rabbitmq jenkins mail-server ldap ldap-seed
+      docker-compose -f src/main/docker/docker-compose.yml up -d eiffel-er mongodb rabbitmq jenkins mail-server ldap ldap-seed ldap2 ldap2-seed
     fi
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ before_install:
   - |
     if [[ $TRAVIS_JOB_NAME = integrationTests ]]; then
       source src/main/docker/env.bash
-      docker-compose -f src/main/docker/docker-compose.yml up -d eiffel-er mongodb rabbitmq jenkins mail-server ldap ldap-seed ldap2 ldap2-seed
+      docker-compose -f src/main/docker/docker-compose.yml up -d eiffel-er mongodb rabbitmq jenkins mail-server ldap ldap-seed
     fi
 
 

--- a/src/main/resources/static/js/common.js
+++ b/src/main/resources/static/js/common.js
@@ -106,7 +106,9 @@ function isStringDefined(value) {
 
 function parseJSON(value) {
     try {
-        if (typeof value === 'number' || value.match(/^\d+$/) || value.match(/^(true|false)$/)) {
+        var isNumber = "/^\d+$/";
+        var isBoolean = "/^(true|false)$/";
+        if (typeof value === 'number' || value.match(isNumber) || value.match(isBoolean)) {
             return undefined;
         }
         return JSON.parse(value);

--- a/src/main/resources/static/js/common.js
+++ b/src/main/resources/static/js/common.js
@@ -106,12 +106,12 @@ function isStringDefined(value) {
 
 function parseJSON(value) {
     try {
-        var isNumber = "/^\d+$/";
-        var isBoolean = "/^(true|false)$/";
-        if (typeof value === 'number' || value.match(isNumber) || value.match(isBoolean)) {
+        var json = JSON.parse(value);
+        if (json !== null && typeof json === "object") {
+            return json;
+        } else {
             return undefined;
         }
-        return JSON.parse(value);
     } catch (e) {
         return undefined;
     }

--- a/src/main/resources/static/js/common.js
+++ b/src/main/resources/static/js/common.js
@@ -104,6 +104,17 @@ function isStringDefined(value) {
     return isDefined;
 }
 
+function parseJSON(value) {
+    try {
+        if (typeof value === 'number' || value.match(/^(true|false)$/)) {
+            return undefined;
+        }
+        return JSON.parse(value);
+    } catch (e) {
+        return undefined;
+    }
+}
+
 // /Stop ## Common functions ##################################
 
 // Start ## Routing ##

--- a/src/main/resources/static/js/common.js
+++ b/src/main/resources/static/js/common.js
@@ -104,7 +104,7 @@ function isStringDefined(value) {
     return isDefined;
 }
 
-function parseJSON(value) {
+function parseJsonObject(value) {
     try {
         var json = JSON.parse(value);
         if (json !== null && typeof json === "object") {

--- a/src/main/resources/static/js/common.js
+++ b/src/main/resources/static/js/common.js
@@ -106,7 +106,7 @@ function isStringDefined(value) {
 
 function parseJSON(value) {
     try {
-        if (typeof value === 'number' || value.match(/^(true|false)$/)) {
+        if (typeof value === 'number' || value.match(/^\d+$/) || value.match(/^(true|false)$/)) {
             return undefined;
         }
         return JSON.parse(value);

--- a/src/main/resources/static/js/information.js
+++ b/src/main/resources/static/js/information.js
@@ -109,9 +109,17 @@ jQuery(document).ready(function () {
         tdKey.setAttribute('class', 'left-table-pane');
         tdKey.appendChild(document.createTextNode(key));
         tr.appendChild(tdKey);
-        var tdValue = document.createElement('td');
-        tdValue.appendChild(document.createTextNode(value));
-        tr.appendChild(tdValue);
+        var element = document.createElement('td');
+        var json = parseJSON(value);
+        if (json != undefined) {
+            value = JSON.stringify(json, undefined, 2);
+            pre = document.createElement('pre');
+            pre.appendChild(document.createTextNode(value));
+            element.appendChild(pre);
+        } else {
+            element.appendChild(document.createTextNode(value));
+        }
+        tr.appendChild(element);
         return tr;
     }
 

--- a/src/main/resources/static/js/information.js
+++ b/src/main/resources/static/js/information.js
@@ -110,7 +110,7 @@ jQuery(document).ready(function () {
         tdKey.appendChild(document.createTextNode(key));
         tr.appendChild(tdKey);
         var element = document.createElement('td');
-        var json = parseJSON(value);
+        var json = parseJsonObject(value);
         if (json != undefined) {
             value = JSON.stringify(json, undefined, 2);
             pre = document.createElement('pre');


### PR DESCRIPTION
### Applicable Issues
Related to https://github.com/eiffel-community/eiffel-intelligence/pull/315

### Description of the Change
Information that can be parsed into JSON will now be inside a pre block to display it in pretty format.
Strings that are parsed into numbers and booleans are excluded otherwise json parser will treat these as json.

### Alternate Designs

### Benefits

### Possible Drawbacks

### Sign-off
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Christoffer Cortes Sjöwall, christoffer.cortes.sjowall@ericsson.com
