### PR TITLE
Change expected structure of aggregated object in tests

### DIFF
--- a/src/integrationtest/java/com/ericsson/ei/frontend/CommonSteps.java
+++ b/src/integrationtest/java/com/ericsson/ei/frontend/CommonSteps.java
@@ -143,7 +143,6 @@ public class CommonSteps extends AbstractTestExecutionListener {
     }
 
     @When("^username \"([^\"]*)\" and password \"([^\"]*)\" is used as credentials$")
-    //@When("^username \"(\\w+)\" and password \"(\\w+)\" is used as credentials$")
     public void with_credentials(String username, String password) throws Throwable {
         String auth = username + ":" + password;
         String encodedAuth = new String(Base64.encodeBase64(auth.getBytes()), "UTF-8");

--- a/src/integrationtest/java/com/ericsson/ei/frontend/CommonSteps.java
+++ b/src/integrationtest/java/com/ericsson/ei/frontend/CommonSteps.java
@@ -142,7 +142,8 @@ public class CommonSteps extends AbstractTestExecutionListener {
         httpRequest.setBody(body);
     }
 
-    @When("^username \"(\\w+)\" and password \"(\\w+)\" is used as credentials$")
+    @When("^username \"([^\"]*)\" and password \"([^\"]*)\" is used as credentials$")
+    //@When("^username \"(\\w+)\" and password \"(\\w+)\" is used as credentials$")
     public void with_credentials(String username, String password) throws Throwable {
         String auth = username + ":" + password;
         String encodedAuth = new String(Base64.encodeBase64(auth.getBytes()), "UTF-8");

--- a/src/integrationtest/resources/bodies/queryFreestyle.json
+++ b/src/integrationtest/resources/bodies/queryFreestyle.json
@@ -1,5 +1,5 @@
 {
   "criteria": {
-    "aggregatedObject.identity": "pkg:maven/com.mycompany.myproduct/artifact-name@2.0.0"
+    "identity": "pkg:maven/com.mycompany.myproduct/artifact-name@2.0.0"
   }
 }

--- a/src/integrationtest/resources/integration-test.properties
+++ b/src/integrationtest/resources/integration-test.properties
@@ -55,13 +55,6 @@ spring.data.mongodb.database: eiffel_intelligence
 server.session-timeout: 1200
 sessions.collection.name: sessions
 
-# name of the aggregated object for user to prefix each query criteria
-# This property will be used as a prefix to each criteria of the
-# query. It is replaced dynamically with the name of the object stored, in
-# the data base.
-search.query.prefix: object
-# name of the aggregated object in the collection
-aggregated.object.name: aggregatedObject
 # name of the collection where aggregated objects are stored
 aggregated.collection.name: aggregated_objects
 # time to live value in seconds for aggregated objects.

--- a/src/integrationtest/resources/responses/rulesAggregation.json
+++ b/src/integrationtest/resources/responses/rulesAggregation.json
@@ -1,39 +1,37 @@
 [
     {
         "_id": "df4cdb42-1580-4cff-b97a-4d0faa9b2b22_ARTIFACT_TEST",
-        "aggregatedObject": {
-            "fileInformation": [
-                {
-                    "extension": "war",
-                    "classifier": ""
-                }
-            ],
-            "buildCommand": "trigger",
-            "identity": "pkg:maven/com.mycompany.myproduct/artifact-name@2.0.0",
-            "confidenceLevels": [
-                {
-                    "eventId": "e3be0cf8-2ebd-4d6d-bf5c-a3b535cd084e_ARTIFACT_TEST",
-                    "name": "dummy_1_stable",
-                    "time": 1521452400324,
-                    "value": "SUCCESS"
-                }
-            ],
-            "TemplateName": "ARTIFACT_TEST",
-            "id": "df4cdb42-1580-4cff-b97a-4d0faa9b2b22_ARTIFACT_TEST",
-            "time": 1521452368194,
-            "type": "EiffelArtifactCreatedEvent",
-            "publications": [
-                {
-                    "eventId": "2acd348d-05e6-4945-b441-dc7c1e55534e_ARTIFACT_TEST",
-                    "locations": [
-                        {
-                            "type": "NEXUS",
-                            "uri": "http://localhost:8081/repository/test"
-                        }
-                    ],
-                    "time": 1521452368758
-                }
-            ]
-        }
+        "fileInformation": [
+            {
+                "extension": "war",
+                "classifier": ""
+            }
+        ],
+        "buildCommand": "trigger",
+        "identity": "pkg:maven/com.mycompany.myproduct/artifact-name@2.0.0",
+        "confidenceLevels": [
+            {
+                "eventId": "e3be0cf8-2ebd-4d6d-bf5c-a3b535cd084e_ARTIFACT_TEST",
+                "name": "dummy_1_stable",
+                "time": 1521452400324,
+                "value": "SUCCESS"
+            }
+        ],
+        "TemplateName": "ARTIFACT_TEST",
+        "id": "df4cdb42-1580-4cff-b97a-4d0faa9b2b22_ARTIFACT_TEST",
+        "time": 1521452368194,
+        "type": "EiffelArtifactCreatedEvent",
+        "publications": [
+            {
+                "eventId": "2acd348d-05e6-4945-b441-dc7c1e55534e_ARTIFACT_TEST",
+                "locations": [
+                    {
+                        "type": "NEXUS",
+                        "uri": "http://localhost:8081/repository/test"
+                    }
+                ],
+                "time": 1521452368758
+            }
+        ]
     }
 ]


### PR DESCRIPTION

### Applicable Issues
Because Eiffel Intelligence back-end have updated the way it stores aggregated objects, the syntax for performing queries towards them changes.


### Description of the Change
Updated integration tests to adapt to the new structure of aggregated objects. Removed two unused integration test properties which are no longer needed. Changed regex to make cucumber recognize a test step that was previously skipped.

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits
Integration tests are now passing.

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Emelie Pettersson emelie.pettersson@ericsson.com
