### PR TITLE
Update docker-compose with EI 2.0.0

### DIFF
--- a/src/main/docker/docker-compose.yml
+++ b/src/main/docker/docker-compose.yml
@@ -251,7 +251,7 @@ services:
       eiffel_2.0_1:
         aliases:
           - ei-backend-artifact
-    environment:       # Overrides settings in application config file
+    environment:       # Overrides settings in application.properties file
       - SpringApplicationName=ei-backend-artifact
       - server.port=8080
       - rules.path=/rules/ArtifactRules-Eiffel-Agen-Version.json
@@ -267,13 +267,12 @@ services:
       - spring.data.mongodb.port=${MONGODB_PORT}
       - spring.data.mongodb.database=eiffel-intelligence-artifact
       - missedNotificationDataBaseName=MissedNotification-artifact
-      - search.query.prefix=object
-      - aggregated.object.name=aggregatedObject
+      - aggregated.collection.name=aggregated-objects-artifact
       - spring.mail.properties.mail.smtp.auth=false
       - spring.mail.properties.mail.smtp.starttls.enable=false
       - er.url=http://eiffel-er:${EIFFEL_ER_INTERNAL_PORT}/search
-      - logging.level.root=OFF
-      - logging.level.org.springframework.web=DEBUG
+      - logging.level.root=ERROR
+      - logging.level.org.springframework.web=ERROR
       - logging.level.com.ericsson.ei=DEBUG
       - WAIT_MB_HOSTS=rabbitmq:${RABBITMQ_WEB_PORT}
       - WAIT_DB_HOSTS=mongodb:${MONGODB_PORT}
@@ -302,7 +301,7 @@ services:
       eiffel_2.0_1:
         aliases:
           - ei-backend-sourcechange
-    environment:       # Overrides settings in application config file
+    environment:       # Overrides settings in application.properties file
       - SpringApplicationName=ei-backend-sourcechange
       - server.port=8080
       - rules.path=/rules/SourceChangeObjectRules-Eiffel-Agen-Version.json
@@ -318,13 +317,12 @@ services:
       - spring.data.mongodb.port=${MONGODB_PORT}
       - spring.data.mongodb.database=eiffel-intelligence-sourcechange
       - missedNotificationDataBaseName=MissedNotification-sourcechange
-      - search.query.prefix=object
-      - aggregated.object.name=aggregatedObject
+      - aggregated.collection.name=aggregated-objects-sourcechange
       - spring.mail.properties.mail.smtp.auth=false
       - spring.mail.properties.mail.smtp.starttls.enable=false
       - er.url=http://eiffel-er:${EIFFEL_ER_INTERNAL_PORT}/search
-      - logging.level.root=OFF
-      - logging.level.org.springframework.web=DEBUG
+      - logging.level.root=ERROR
+      - logging.level.org.springframework.web=ERROR
       - logging.level.com.ericsson.ei=DEBUG
       - WAIT_MB_HOSTS=rabbitmq:${RABBITMQ_WEB_PORT}
       - WAIT_DB_HOSTS=mongodb:${MONGODB_PORT}
@@ -353,7 +351,7 @@ services:
       eiffel_2.0_1:
         aliases:
           - ei-backend-testexecution
-    environment:       # Overrides settings in application config file
+    environment:       # Overrides settings in application.properties file
       - SpringApplicationName=ei-backend-testexecution
       - server.port=8080
       - rules.path=/rules/TestExecutionObjectRules-Eiffel-Agen-Version.json
@@ -369,8 +367,7 @@ services:
       - spring.data.mongodb.port=${MONGODB_PORT}
       - spring.data.mongodb.database=eiffel-intelligence-testexecution
       - missedNotificationDataBaseName=MissedNotification-testexecution
-      - search.query.prefix=object
-      - aggregated.object.name=aggregatedObject
+      - aggregated.collection.name=aggregated-objects-testexecution
       - spring.mail.host=
       - spring.mail.port=
       - spring.mail.username=
@@ -378,8 +375,8 @@ services:
       - spring.mail.properties.mail.smtp.auth=false
       - spring.mail.properties.mail.smtp.starttls.enable=false
       - er.url=http://eiffel-er:${EIFFEL_ER_INTERNAL_PORT}/search
-      - logging.level.root=OFF
-      - logging.level.org.springframework.web=DEBUG
+      - logging.level.root=ERROR
+      - logging.level.org.springframework.web=ERROR
       - logging.level.com.ericsson.ei=DEBUG
       - WAIT_MB_HOSTS=rabbitmq:${RABBITMQ_WEB_PORT}
       - WAIT_DB_HOSTS=mongodb:${MONGODB_PORT}
@@ -407,7 +404,7 @@ services:
       eiffel_2.0_1:
         aliases:
           - ei-frontend
-    environment:      # Overrides settings in application config file
+    environment:      # Overrides settings in application.properties file
       - spring.application.name=eiffel-intelligence-frontend
       - server.port=8080
       - ei.frontend.service.host=${HOST}
@@ -415,8 +412,8 @@ services:
       - ei.frontend.context.path=
       - ei.backend.instances.list.json.content=${EI_INSTANCES_LIST}
       - ei.backend.instances.filepath=/tmp/eiInstancesListFile.json
-      - logging.level.root=OFF
-      - logging.level.org.springframework.web=DEBUG
+      - logging.level.root=ERROR
+      - logging.level.org.springframework.web=ERROR
       - logging.level.com.ericsson.ei=DEBUG
 
   ldap:

--- a/src/main/docker/env.bash
+++ b/src/main/docker/env.bash
@@ -14,8 +14,8 @@ export MAILSERVER_IMAGE="mailhog/mailhog"
 export REMREM_GENERATE_IMAGE="eiffelericsson/eiffel-remrem-generate:2.0.4"
 export REMREM_PUBLISH_IMAGE="eiffelericsson/eiffel-remrem-publish:2.0.2"
 export JENKINS_IMAGE="bitnami/jenkins:2.138.3"
-export EI_BACKEND_IMAGE="eiffelericsson/eiffel-intelligence-backend:1.0.2"
-export EI_FRONTEND_IMAGE="eiffelericsson/eiffel-intelligence-frontend:1.0.3"
+export EI_BACKEND_IMAGE="eiffelericsson/eiffel-intelligence-backend:2.0.0"
+export EI_FRONTEND_IMAGE="eiffelericsson/eiffel-intelligence-frontend:2.0.0"
 export LDAP_IMAGE="osixia/openldap:1.2.4"
 
 export MONGODB_PORT=27017


### PR DESCRIPTION

### Applicable Issues
docker-compose.yml did not refer to latest version of Eiffel Intelligence docker images.

### Description of the Change
Updated the version of Eiffel Intelligence front-end and back-end docker images to use 2.0.0. Tested locally to run the system tests and they all passed. Changed logging levels of spring framework to ERROR


### Benefits
Version 2.0.0 can be set up easily with this docker-compose file.

### Possible Drawbacks
None that I can think of.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Emelie Pettersson emelie.pettersson@ericsson.com
