### PR TITLE
Changed backend port to 8090

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -21,7 +21,7 @@ ei.use.secure.http.frontend=false
 ######## EI Default Back-Ends
 ei.backend.instances.filepath=
 #ei.backend.instances.list.json.content=
-ei.backend.instances.list.json.content=[{"name":"EI-Backend-1","host":"localhost","port":8070,"contextPath":"","https":false,"defaultBackend":true}]
+ei.backend.instances.list.json.content=[{"name":"EI-Backend-1","host":"localhost","port":8090,"contextPath":"","https":false,"defaultBackend":true}]
 
 ###### EI Documentation Link Url ##########
 ei.eiffel.documentation.urls={ "EI front-end documentation": "https://eiffel-community.github.io/eiffel-intelligence-frontend",\


### PR DESCRIPTION
<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests.
-->

### Applicable Issues


### Description of the Change
The default port which the frontend connected to the backend was changed to 8070 despite the default port in the backend is 8090.

### Alternate Designs
None

### Benefits
The frontend will start without have to change the code

### Possible Drawbacks
None

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Mattias Linnér mattias.linner@ericsson.com
