### PR TITLE
Update documentation links

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -19,11 +19,9 @@ ei.use.secure.http.frontend=false
 ei.backend.instances.list.json.content=[{"name":"EI-Backend-1","host":"localhost","port":8090,"contextPath":"","https":false,"defaultBackend":true}]
 
 ###### EI Documentation Link Url ##########
-ei.eiffel.documentation.urls={ "EI front-end documentation": "https://eiffel-community.github.io/eiffel-intelligence-frontend",\
-                               "EI front-end GitHub": "https://github.com/eiffel-community/eiffel-intelligence-frontend",\
-                               "EI back-end documentation": "https://eiffel-community.github.io/eiffel-intelligence",\
-                               "EI back-end GitHub": "https://github.com/eiffel-community/eiffel-intelligence",\
-                               "Eiffel Github main page": "https://github.com/eiffel-community/eiffel",\
+ei.eiffel.documentation.urls={ "EI front-end on GitHub": "https://github.com/eiffel-community/eiffel-intelligence-frontend",\
+                               "EI back-end on GitHub": "https://github.com/eiffel-community/eiffel-intelligence",\
+                               "Eiffel protocol on Github": "https://github.com/eiffel-community/eiffel",\
                                "User guide for test rules page": "https://github.com/eiffel-community/eiffel-intelligence-frontend/blob/master/wiki/test-rules.md" }
 
 #### LOGGING #########


### PR DESCRIPTION

### Applicable Issues
The links defined in application.properties (visible in the GUI) were still pointing to the non-existing github-pages branch. 

### Description of the Change
Remove the links to github.io and only kept the ones to the source code repositories.

### Alternate Designs


### Benefits
No broken documentation links in the Eiffel Intelligence GUI.


### Possible Drawbacks
None.

### Sign-off


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Emelie Pettersson emelie.pettersson@ericsson.com
