### PR TITLE
Fix broken link to test-rules user guide docs on GitHub

### DIFF
--- a/src/main/resources/templates/test-rules.html
+++ b/src/main/resources/templates/test-rules.html
@@ -152,7 +152,7 @@
             <div class="modal-body modal-height-fit">
                 <p id="infoContent" class="pre"></p>
                 <div class="text-center">
-                    <a href="https://github.com/eiffel-community/eiffel-intelligence-frontend/blob/master/wiki/markdown/test-rules.md"
+                    <a href="https://github.com/eiffel-community/eiffel-intelligence-frontend/blob/master/wiki/test-rules.md"
                         target="_blank" rel="noopener noreferrer" style="text-decoration: none;">Test Rules User
                         Guide</a>
                 </div>


### PR DESCRIPTION

### Applicable Issues
Discovered a broken link when I played around with the test rules page locally.

### Description of the Change
The documentation on GitHub has moved so I fixed the link.

### Alternate Designs
None.

### Benefits
Working link, making it easier for users to find the documentation 😄 

### Possible Drawbacks
None

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Emelie Pettersson emelie.pettersson@ericsson.com
