### PR TITLE
Add zero-downtime EntraID client secret hot-swap

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,6 +115,11 @@
             <version>7.0.0</version>
         </dependency>
         <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-context</artifactId>
+            <version>5.0.1</version>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-oauth2-client</artifactId>
         </dependency>

--- a/src/main/java/com/ericsson/ei/frontend/EIRequestsController.java
+++ b/src/main/java/com/ericsson/ei/frontend/EIRequestsController.java
@@ -63,7 +63,7 @@ public class EIRequestsController {
 
     @Autowired
     private EIRequestsControllerUtils eiRequestsControllerUtils;
-    @Autowired
+    @Autowired(required = false)
     private EntraIdTokenIssuer entraIdTokenIssuer;
     @Value("${spring.cloud.azure.active-directory.enabled}")
     private Boolean azureEnabled;

--- a/src/main/java/com/ericsson/ei/frontend/config/SecurityConfigAzureAD.java
+++ b/src/main/java/com/ericsson/ei/frontend/config/SecurityConfigAzureAD.java
@@ -4,6 +4,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -29,6 +30,17 @@ public class SecurityConfigAzureAD {
     private String tenantId;
 
     @Bean
+    @Order(1)
+    public SecurityFilterChain actuatorFilterChain(HttpSecurity http) throws Exception {
+        http
+            .securityMatcher("/actuator/**")
+            .csrf(csrf -> csrf.disable())
+            .authorizeHttpRequests(auth -> auth.anyRequest().permitAll());
+        return http.build();
+    }
+
+    @Bean
+    @Order(2)
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
             .csrf(csrf -> csrf.disable())

--- a/src/main/java/com/ericsson/ei/frontend/utils/EntraIdTokenIssuer.java
+++ b/src/main/java/com/ericsson/ei/frontend/utils/EntraIdTokenIssuer.java
@@ -1,14 +1,26 @@
 package com.ericsson.ei.frontend.utils;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.cloud.context.config.annotation.RefreshScope;
+import org.springframework.cloud.context.scope.refresh.RefreshScopeRefreshedEvent;
+import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 
 import com.azure.core.credential.TokenCredential;
 import com.azure.core.credential.TokenRequestContext;
 import com.azure.identity.ClientSecretCredentialBuilder;
 
+import jakarta.annotation.PostConstruct;
+
 @Component
+@RefreshScope
+@ConditionalOnProperty(name = "spring.cloud.azure.active-directory.enabled", havingValue = "true")
 public class EntraIdTokenIssuer {
+
+    private static final Logger LOG = LoggerFactory.getLogger(EntraIdTokenIssuer.class);
 
     @Value("${spring.cloud.azure.active-directory.credential.client-id}")
     private String clientId;
@@ -22,25 +34,36 @@ public class EntraIdTokenIssuer {
     @Value("${spring.cloud.azure.active-directory.api-scope}")
     private String scope;
 
+    private TokenCredential credential;
+
+    @PostConstruct
+    @EventListener(RefreshScopeRefreshedEvent.class)
+    public void refreshCredential() {
+        TokenCredential newCredential = new ClientSecretCredentialBuilder()
+            .clientId(clientId)
+            .clientSecret(clientSecret)
+            .tenantId(tenantId)
+            .build();
+
+        // Validate by acquiring a token before accepting the new credential
+        try {
+            newCredential.getToken(new TokenRequestContext().addScopes(scope)).block();
+            this.credential = newCredential;
+            LOG.info("Azure AD credentials refreshed and validated for client-id: {}", clientId);
+        } catch (Exception e) {
+            LOG.error("New client secret validation FAILED for client-id: {}", clientId, e);
+            throw new IllegalStateException("Client secret refresh failed validation", e);
+        }
+    }
+
     /**
      * Retrieves an access token for the configured Azure AD scope.
      * @return the access token as a string
-     * @throws RuntimeException if token retrieval fails
      */
     public String getAccessToken() {
-            // Build the ClientSecretCredential using Spring's property values
-            TokenCredential clientSecretCredential = new ClientSecretCredentialBuilder()
-                .clientId(clientId)
-                .clientSecret(clientSecret)
-                .tenantId(tenantId)
-                .build();
-            // Get the token using the scope defined (default is ".default")
-            String token = clientSecretCredential
-                .getToken(new TokenRequestContext().addScopes(scope))
-                .block()
-                .getToken();
-
-            // Return the token string
-            return token;
+        return credential
+            .getToken(new TokenRequestContext().addScopes(scope))
+            .block()
+            .getToken();
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -36,3 +36,10 @@ spring.cloud.azure.active-directory.api-scope=
 logging.level.root: INFO
 logging.level.org.springframework.web: INFO
 logging.level.com.ericsson.ei: INFO
+
+#### SPRING CLOUD #########
+spring.cloud.bootstrap.enabled=false
+
+#### ACTUATOR #########
+management.endpoints.web.exposure.include=health,info,refresh
+management.endpoint.refresh.enabled=true


### PR DESCRIPTION
Enable runtime refresh of Azure AD client secret without application restart using Spring Cloud Context @RefreshScope and /actuator/refresh endpoint.

## Changes
- Add spring-cloud-context:5.0.1 dependency
- Add @RefreshScope to EntraIdTokenIssuer with credential rebuild on refresh event
- Disable Spring Cloud bootstrap (incompatible with WAR/Tomcat deployment)
- Expose actuator refresh endpoint
- Add separate SecurityFilterChain for /actuator/** to bypass OAuth2

## How to use
```bash
# 1. Update client-secret in application.properties
# 2. Trigger refresh:
curl -X POST https://<host>:8443/eifrontend/actuator/refresh -H "Content-Type: application/json" -d '{}'
```

## Tested
- Spring Boot 4.0.4, WAR on external Tomcat
- Jasypt ENC() decryption verified on refresh
- No restart, same PID throughout