### PR TITLE
Enable Dependabot version updates for Maven dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,9 @@ updates:
       interval: weekly
       day: sunday
     open-pull-requests-limit: 10
+
+  - package-ecosystem: maven
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10


### PR DESCRIPTION
(Create with some help of my AI agent)

### Applicable Issues

Enables Dependabot to propose PRs for outdated Maven dependencies, allowing
security alerts with available fixes to be addressed via automated PRs.

### Description of the Change

The current `dependabot.yml` only configures version updates for GitHub Actions.
This means Dependabot detects Maven vulnerabilities but never creates PRs to
fix them — even when a newer version of a direct dependency is available
(e.g. `spring-boot-starter-parent` is at 4.0.4, while 4.0.6 is available).

This change adds a `maven` ecosystem entry so Dependabot can propose version
bumps for direct dependencies on a weekly basis.

### Alternate Designs

- Manual version bumps: works but relies on someone noticing and acting on alerts.
- Renovate Bot: more configurable but adds complexity for a simple need.

### Possible Drawbacks

- Dependabot will open PRs weekly for outdated dependencies, which may create noise.
  The `open-pull-requests-limit: 10` cap keeps this manageable.
- Transitive dependency CVEs (e.g. Tomcat, Netty) still will not get auto-PRs since
  Dependabot can only bump directly declared versions.

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Mattias Linnér <mattias.linner@ericsson.com>